### PR TITLE
Harden daemon socket access and make install updates idempotent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,12 @@ jobs:
 
       - name: Test
         run: swift test
+
+  package-smoke:
+    runs-on: macos-15
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Package smoke
+        run: ./Scripts/ci-smoke.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-release-artifacts:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build release binaries
+        run: swift build -c release
+
+      - name: Build app bundle
+        run: ./Scripts/build-app-bundle.sh ./ThermalForge.app
+
+      - name: Archive artifacts
+        run: |
+          mkdir -p dist
+          tar -czf dist/thermalforge-cli-macos-arm64.tar.gz -C .build/release thermalforge
+          ditto -c -k --sequesterRsrc --keepParent ThermalForge.app dist/ThermalForge.app.zip
+          shasum -a 256 dist/* > dist/checksums.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: thermalforge-release-artifacts
+          path: dist/*

--- a/README.md
+++ b/README.md
@@ -1,93 +1,32 @@
 # ThermalForge
 
-**Free, open-source fan control for Apple Silicon Macs.** Menu bar app + CLI.
+Open-source fan control for Apple Silicon Macs.
 
-Built in 2026 with Swift. No subscriptions, no telemetry, no ads.
-
-[![CI](https://github.com/ProducerGuy/ThermalForge/actions/workflows/ci.yml/badge.svg)](https://github.com/ProducerGuy/ThermalForge/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![macOS 14+](https://img.shields.io/badge/macOS-14%2B-black?logo=apple)](https://www.apple.com/macos/)
-[![Apple Silicon](https://img.shields.io/badge/Apple%20Silicon-M1%E2%80%93M5-orange)](https://support.apple.com/en-us/116943)
-
----
-
-## Why ThermalForge?
-
-Tools like **Macs Fan Control** and **TG Pro** charge $15–$20 for fan control that hasn't fundamentally improved in years. Both require manual configuration, neither learns anything about your machine, and both have documented problems on Apple Silicon.
-
-| Feature | ThermalForge | Macs Fan Control | TG Pro |
-|---|---|---|---|
-| Smart adaptive fan curve | **Yes** | No | No |
-| Machine-specific calibration | **Coming soon** | No | No |
-| Multi-sensor safety | **Yes — all sensors** | [One sensor per fan](https://github.com/crystalidea/macs-fan-control/issues/266) | Manual rules only |
-| Proactive cooling (ramps before throttle) | **Yes** | No | No |
-| Fan curve type | Per-profile shapes (ease-in, linear, S-curve, instant) | Linear between 2 points | Manual step-function |
-| Real-time temp monitoring | Yes | Yes | Yes |
-| Menu bar app | Yes | Yes | Yes |
-| CLI access | **Yes** | No | No |
-| Thermal data logging (CSV) | **Yes** | No | Yes |
-| Process correlation in logs | **Yes** | No | No |
-| Sleep/wake re-apply | Yes | Yes | Yes |
-| Safety override (95°C) | **Yes — always active** | No | Requires manual setup |
-| Crash recovery (heartbeat watchdog) | **Yes** | Reverts on quit only | Override removes macOS safety |
-| Open source | **Yes** | No | No |
-| Price | **Free** | $15 | $20 |
-
-### Known problems with alternatives
-
-**Macs Fan Control** monitors only one temperature sensor per fan. Users have reported [GPU overheating while monitoring CPU only](https://github.com/crystalidea/macs-fan-control/issues/266), leading to system lockups. Fan control is [broken on M3/M4 Pro and Max](https://github.com/crystalidea/macs-fan-control/issues/785) due to Apple firmware changes.
-
-**TG Pro** offers more flexibility but requires users to manually configure step-function rules for each fan speed threshold. Its "Override System" mode removes macOS thermal safety entirely — if your rules are wrong, there's no backstop. No learning, no adaptation, no calibration.
-
-**AlDente Pro** ($30) is a battery management tool with no fan control features. It monitors battery temperature and pauses charging — it does not control fans.
+- Native Swift CLI + menu bar app
+- Privileged launchd daemon (no repeated sudo prompts)
+- Safety-first thermal control with 95°C override
+- Profile curves + IF/THEN rule engine
+- Research logging (CSV + JSON metadata)
 
 ## Features
 
-- Real-time CPU, GPU, RAM, SSD, and ambient temperatures in the menu bar
-- Five fan profiles with proportional curves (not binary on/off)
-- Thermal logging — CSV + JSON data export with process correlation for research
-- Automatic fan re-apply after sleep/wake
-- Fahrenheit / Celsius toggle
-- Safety override: forces max fans if any sensor hits 95°C
-- Crash recovery: heartbeat watchdog resets fans if app dies
-- Temperature anomaly detection: logs instant spikes (>5°C in 2s) and sustained changes (>10°C in 30s) with process capture
-- Privileged daemon — one-time sudo, zero password prompts after
-- Native Swift — lightweight, no Electron, no bloat
-
-## Profiles
-
-Every profile uses a proportional curve with a per-profile curve shape — fans ramp gradually with temperature, not as binary switches. All profiles share a unified 50°C off threshold (matching Apple's observed behavior). Each profile has its own sustained trigger duration — fans only engage after temperature stays above the start threshold for a profile-specific number of seconds, filtering transient spikes that resolve on their own. Reacting to transient spikes would cause the start/stop cycling that is the #1 cause of fan bearing wear (source: [Analog Devices fan control](https://www.analog.com/en/analog-dialogue/articles/how-to-control-fan-speed.html)).
-
-Thermal polling runs at 100ms (matching Apple's own thermalmonitord cadence) for smooth fan transitions. Each profile has its own ramp rates and curve shape tuned to its purpose. Ramp governor design sourced from [MAX31760 datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/max31760.pdf) and [Microchip AN771](https://ww1.microchip.com/downloads/en/appnotes/00771a.pdf).
-
-| Profile | Fans off | Fans start | Ceiling | Max fan | Curve | Sustained trigger | Behavior |
-|---|---|---|---|---|---|---|---|
-| **Silent (Apple Default)** | N/A | N/A | N/A | Apple | N/A | N/A | Monitoring only. Apple controls fans. |
-| **Balanced** | 50°C | 55°C | 70°C | 60% | Ease-in (pos²) | 8 seconds | Quiet at low temps, ramps harder as heat builds. |
-| **Performance** | 50°C | 55°C | 65°C | 85% | Linear | 4 seconds | Direct proportional response, 2× ramp-up speed. |
-| **Max** | 50°C | 65°C | — | 100% | Instant | 5 seconds | Attack dog: instant 100% when triggered, S-curve ramp-down. |
-| **Smart** | 50°C | 53°C | 85°C | 100% | S-curve | 6 seconds | Proactive with rate-of-change awareness. Starts 2°C earlier. |
-
-**How profiles work:**
-- **Below 50°C:** All fans off. Machine is at idle.
-- **50°C–start (hysteresis zone):** Fans maintain current state. Already running → stay at minimum. Already off → stay off.
-- **Above start for N seconds:** Fans engage. Balanced and Performance ramp proportionally using their curve shape. Max jumps instantly to 100%.
-- **Between start and ceiling:** Fan speed scales based on the profile's curve shape. Balanced (ease-in) is quiet at low temps — at 62.5°C (midpoint of 55–70°C), fans run at only 15% of max RPM instead of 30% linear. Performance (linear) is proportional. Max has no proportional zone — it's binary.
-- **At ceiling and above:** Fan speed at the profile's maximum (60%/85%/100%).
-- **Ramp down:** Each profile has its own ramp-down rate. Max uses a gentle governor to let temps stabilize before backing off.
+- Profiles: Silent, Balanced, Performance, Max, Smart
+- Rule engine (priority-based):
+  - Example: `IF maxTemp >= 55 THEN set max fan until <= 65`
+- Sleep/wake command re-apply via daemon
+- Heartbeat watchdog resets fans if app dies
+- Structured event logging (`jsonl`) + rotating plain logs
 
 ## Install
 
-### Option A: Homebrew (recommended)
+### Homebrew
 
 ```bash
 brew install ProducerGuy/tap/thermalforge
 sudo thermalforge install
 ```
 
-The first command installs the CLI and the menu bar app to `/Applications`. The second sets up a background daemon so the app can control fans without needing sudo every time. You only run it once.
-
-### Option B: From source
+### From Source
 
 ```bash
 git clone https://github.com/ProducerGuy/ThermalForge.git
@@ -95,228 +34,68 @@ cd ThermalForge
 ./setup.sh
 ```
 
-Builds everything, installs the CLI, creates the menu bar app in `/Applications`, and sets up the daemon. One password prompt, fully automatic.
+`setup.sh` now uses a hardened app-bundle builder:
+- `Scripts/build-app-bundle.sh`
+- validated `Info.plist`
+- executable permission checks
+- ad-hoc signing + quarantine cleanup
 
-### After install
-
-Open ThermalForge from Spotlight, Finder (Applications > ThermalForge), or terminal:
+## Run
 
 ```bash
 open /Applications/ThermalForge.app
 ```
 
-Turn on **Launch at Login** in the menu bar dropdown and it starts automatically on every boot.
-
-## Smart Profile
-
-### Why proactive cooling matters
-
-Apple's default fan behavior is reactive: fans stay off until the chip is already hot, then ramp up to recover. This creates a repeating cycle during sustained workloads like renders, compiles, and ML inference:
-
-1. CPU/GPU runs at full clocks, heat builds unchecked
-2. Chip hits ~90°C, starts throttling clock speeds — **10-20% performance loss**
-3. Fans finally ramp up
-4. Temps drop, clocks recover, fans slow down
-5. Heat builds again — repeat
-
-This sawtooth pattern costs you sustained performance, wears hardware faster (thermal cycling stress on solder joints follows the Coffin-Manson fatigue model — damage scales with temperature swing amplitude, not absolute temperature), and forces fans to work harder because they're always recovering instead of preventing.
-
-The Smart profile eliminates this. It monitors temperature velocity — not just where the temp is, but how fast it's rising — and ramps fans early enough to hold the chip below 85°C. The result: sustained peak clocks throughout your entire workload, less thermal cycling wear, and fans that run quieter overall because they never need to recover from a heat spike.
-
-Apple doesn't do this because silence sells in store demos and most users never run sustained workloads. ThermalForge gives power users the choice Apple doesn't.
-
-### How Smart works
-
-**The curve:** Smart maps temperature to fan speed across a 53–85°C range using an S-curve (gentle at both ends, steeper in the middle). Below 50°C, fans turn off. Between 50–53°C, fans maintain current state (hysteresis). Above 85°C, fans go to max.
-
-**Rate-of-change awareness:** Smart doesn't just look at where temperature is — it looks at how fast it's moving. If temp is rising at 1°C/sec, Smart boosts fan speed proportionally to get ahead of the climb. If temp is stable or falling, Smart holds steady or eases off gradually.
-
-**Ramp governors:** Fan speed changes are rate-limited for acoustic comfort. Each profile has its own ramp rates — Smart uses ~400 RPM/sec up, ~200 RPM/sec down. This prevents acoustic shock, reduces mechanical stress, and extends fan bearing lifespan by up to 50% compared to abrupt speed changes (source: [NMB fan engineering](https://nmbtc.com/white-papers/dc-brushless-cooling-fan-behavior/), [Analog Devices ADM1031 datasheet](https://www.onsemi.com/download/data-sheet/pdf/adm1031-d.pdf)).
-
-**Hysteresis:** Fans turn on at 53°C (after 6 seconds sustained) and turn off at 50°C — a 3°C gap. Balanced and Performance use 55°C start with a 5°C gap. Max uses 65°C start with a 15°C gap. This prevents rapid on/off cycling, which is the #1 cause of fan bearing wear in fluid dynamic bearing fans (source: [Nidec FDB technology](https://www.nidec.com/en/technology/capability/fdb/), [AnandTech fan lifespan discussion](https://forums.anandtech.com/threads/fan-stop-start-effect-on-lifespan.2284098/)).
-
-**0 to minimum RPM is binary:** Apple Silicon MacBook fans cannot spin below their minimum RPM (2317 on M5 Max, 1200 on M1 Max). When Smart decides fans should run, they jump directly to minimum — this is a hardware limitation of brushless DC motors that require a startup burst to overcome static friction. Above minimum, all speed changes are smooth and governed.
-
-### FAQ
-
-**What if ThermalForge closes during normal use?**
-The daemon's heartbeat watchdog detects the app is gone within 15 seconds and resets fans to Apple defaults. On next launch, the app resets fans to auto.
-
-### Resets and troubleshooting
-
-**Reset fans right now:**
-```bash
-thermalforge auto
-```
-Kills the app and resets fans to Apple defaults.
-
-**Emergency reset (if nothing else works):**
-```bash
-sudo killall ThermalForgeApp && sudo /usr/local/bin/thermalforge auto
-```
-Force-kills the app and resets fans directly via the daemon.
-
-**Completely remove ThermalForge:**
-```bash
-sudo thermalforge uninstall
-```
-Removes the daemon, binary, app, and all logs. Clean slate.
-
-If installed via Homebrew, run `brew uninstall thermalforge` first.
-
-### Disclaimer
-
-ThermalForge is provided as-is with no warranty. Use at your own risk.
-
 ## CLI
 
 ```bash
-thermalforge status        # JSON output: fan speeds + temps
-thermalforge max           # Max fans (requires daemon or sudo)
-thermalforge auto          # Reset to Apple defaults
-thermalforge set 4000      # Set specific RPM
-thermalforge discover      # Dump all SMC keys (for new hardware)
-thermalforge watch          # Monitor mode with auto-boost profiles
-thermalforge log           # Record thermal data to CSV (1Hz, auto-delete 24h)
-thermalforge log --rate 10 --duration 1h --no-expire   # 10Hz for 1 hour, keep forever
+thermalforge status
+thermalforge max
+thermalforge auto
+thermalforge set 4000
+thermalforge watch --profile smart
+thermalforge discover
+thermalforge log --rate 10 --duration 1h --no-expire
 ```
 
-## Compatibility
+### Rules CLI
 
-Tested on MacBook Pro M5 Max (Mac17,7). Should work on M1–M5 MacBooks.
-Run `thermalforge discover` on your machine and [submit a compatibility report](../../issues/new?template=compatibility-report.md).
+```bash
+thermalforge rules list
+thermalforge rules add --trigger 55 --until 65 --max
+thermalforge rules enable <rule-id>
+thermalforge rules disable <rule-id>
+thermalforge rules remove <rule-id>
+thermalforge rules test --cpu 70 --gpu 62 --profile balanced
+```
 
-| Machine | Chip | Status |
-|---|---|---|
-| MacBook Pro 16" (2025) | M5 Max | Tested |
-| Mac Studio (2022) | M2 Ultra | Tested |
-| MacBook Pro 16" (2021) | M1 Max | Tested |
+## Safety
 
-SMC key names vary across chip generations — ThermalForge auto-detects at startup. The `discover` command dumps all keys so we can verify what your hardware uses. The more machines tested, the more robust ThermalForge becomes.
+- Hard override: any sensor >= 95°C -> max fan
+- Hysteresis + sustained triggers reduce oscillation
+- Daemon authorization: root or active console user only
+- Socket: `/var/run/thermalforge.sock` with restrictive perms
+
+## Development
+
+```bash
+swift build
+swift test
+./Scripts/ci-smoke.sh
+```
+
+CI workflows:
+- `.github/workflows/ci.yml`: build + tests + package smoke
+- `.github/workflows/release.yml`: release artifact packaging
 
 ## Uninstall
 
-### Homebrew
-
-```bash
-brew uninstall thermalforge
-sudo thermalforge uninstall
-```
-
-`thermalforge uninstall` removes the daemon, binary, app, calibration data, and all logs.
-
-### From source
-
 ```bash
 sudo thermalforge uninstall
 ```
 
-This removes the daemon, binary, app bundle, calibration data, and all logs.
-
-## Contributing
-
-ThermalForge is a solo project but compatibility reports are hugely valuable. If you have an Apple Silicon Mac:
-
-1. Install ThermalForge
-2. Run `thermalforge discover --output discover.txt`
-3. [Open a compatibility report](../../issues/new?template=compatibility-report.md) and attach the file
-
-That's it. Every new machine tested makes ThermalForge better for everyone.
-
-## Thermal Logging
-
-No existing macOS tool exports structured thermal data with process correlation in a format designed for research. ThermalForge does.
-
-### Who this is for
-
-- **Data scientists** studying thermal behavior across Apple Silicon generations
-- **Hardware engineers** validating cooling solutions or thermal pad mods
-- **Developers** profiling how their apps affect system thermals
-- **Researchers** who need reproducible, citable thermal data for papers
-
-### What it captures
-
-```bash
-thermalforge log                                          # 1Hz, auto-delete after 24h
-thermalforge log --rate 10 --duration 1h --no-expire      # 10Hz, 1 hour, keep forever
-```
-
-Each session produces a self-contained folder:
-
-| File | Contents |
-|---|---|
-| **thermal.csv** | Timestamped readings from every detected temperature sensor, fan RPM (actual + target), fan mode, at every sample interval |
-| **processes.csv** | Top 5 processes by CPU utilization at every sample — the missing link between thermal data and what caused it |
-| **metadata.json** | Machine model, chip, OS version, ThermalForge version, fan count, RPM range, sample rate, complete sensor dictionary, session start/end, total sample count |
-
-### Why this format
-
-- **CSV + JSON sidecar** — loads directly in pandas, R, Excel, or any data tool without a custom parser
-- **Raw SMC key names** — no friendly labels that could be wrong across chip generations. Cross-reference against Apple hardware documentation directly
-- **Self-describing sessions** — every log folder contains everything needed to interpret the data. Hand it to someone with no context and they can work with it
-- **Auto-delete by default (24h)** — prevents disk bloat for casual users. `--no-expire` for researchers who need to keep data
-
-### Storage
-
-ThermalForge has three types of stored data, all automatically managed:
-
-**App log** (daily files in `~/Library/Logs/ThermalForge/`) — one file per day (`thermalforge-2026-04-05.log`). Records all app events: profile changes, fan commands, temperature spikes, safety overrides, sustained trigger events. Auto-deletes files older than 7 days on app launch. Each daily file is small and easy to open or share.
-
-**Research session logs** (`thermalforge log` exports in `~/Library/Application Support/ThermalForge/logs/`) — CSV/JSON research data. Auto-delete after 24 hours by default. Use `--no-expire` to keep permanently.
-
-Nothing accumulates indefinitely. All cleanup runs automatically on app launch.
-
-## Coming Soon
-
-### Enhanced Logging
-
-- **Thermal throttle state** — capture Apple's `ProcessInfo.thermalState` (nominal/fair/serious/critical) at every sample. Know exactly when and how hard the chip throttled.
-- **Power draw** — SMC power keys (PSTR, PCPT) to capture wattage alongside temperature. Watts correlate directly with heat generation.
-- **GPU utilization** — current logging captures CPU processes but GPU compute workloads (Metal, ML inference) are invisible. GPU utilization fills that gap.
-- **Memory pressure** — system memory pressure percentage at every sample
-- **Delta-T over ambient** — report temperatures as both absolute and delta above ambient. This is the standard comparison metric used by hardware reviewers (Gamers Nexus, Notebookcheck) because absolute temps vary with room temperature.
-- **User markers** — annotate the log mid-session ("started render", "switched profile") so data points have context when analyzed later
-- **Statistical summary** — min, max, mean, standard deviation, P95/P99 for all sensors across the session. Time spent in each thermal state. Peak fan RPM.
-
-### Experiment Mode
-
-A controlled testing framework for anyone who wants to understand their Mac's thermal behavior — modders validating thermal pad swaps, developers profiling their apps, engineers comparing cooling strategies.
-
-```bash
-thermalforge experiment --workload cpu --fan smart --duration 10m --label "smart-baseline"
-thermalforge experiment --workload cpu --fan 75%  --duration 10m --label "fixed-75"
-thermalforge compare smart-baseline fixed-75
-```
-
-**Controlled variables:**
-- Fan speed: any profile, fixed percentage, or Smart
-- Workload type: CPU stress, GPU stress (Metal compute), CPU+GPU combined, idle baseline, or any custom command
-- Duration with automatic steady-state detection (temp change <0.5°C over 2 minutes)
-- Ambient temperature input for Delta-T calculations
-
-**Metrics generated per experiment:**
-- Time-to-throttle — how long before the chip starts losing performance
-- Time-to-steady-state — how long before temperature stabilizes
-- Sustained performance score — average clock throughput over the test duration
-- Statistical summary — mean, std dev, min, max, P95/P99 temps
-
-**Comparison reports:**
-- Side-by-side A/B results across experiments
-- Automatic detection of statistically significant differences
-- Export as CSV or formatted summary
-
-**Built-in workloads:**
-- CPU stress: saturates all cores with compute-bound work
-- GPU stress: Metal compute shaders that load the GPU pipeline
-- Combined: CPU + GPU simultaneously (the real-world worst case for Apple Silicon where CPU, GPU, and Neural Engine share the same die and unified memory)
-- Idle baseline: 5-minute idle measurement before and after tests to establish reference
-
-### Community Thermal Database
-
-Opt-in anonymous upload of experiment results. Compare your machine against others with the same chip. See how your M5 Max thermal performance ranks against the distribution. Modeled after [OpenBenchmarking.org](https://openbenchmarking.org) — standardized methodology, community validation, machine fingerprinting by chip model (not serial number).
-
-See [ROADMAP.md](ROADMAP.md) for full specs and build plans.
+Removes daemon, CLI, app bundle, and ThermalForge user data/logs.
 
 ## License
 
-[MIT](LICENSE) — free to use, modify, and distribute.
+MIT

--- a/README.md
+++ b/README.md
@@ -1,52 +1,134 @@
 # ThermalForge
 
-Open-source fan control for Apple Silicon Macs.
+Low-level fan control for Apple Silicon macOS (14+), implemented in Swift.
 
-- Native Swift CLI + menu bar app
-- Privileged launchd daemon (no repeated sudo prompts)
-- Safety-first thermal control with 95°C override
-- Profile curves + IF/THEN rule engine
-- Research logging (CSV + JSON metadata)
+- Menu bar app (`ThermalForgeApp`)
+- CLI (`thermalforge`)
+- Privileged launchd daemon (`com.thermalforge.daemon`)
 
-## Features
+Original creator: **[ProducerGuy](https://github.com/ProducerGuy/ThermalForge)**.
+This repository is an actively maintained fork.
 
-- Profiles: Silent, Balanced, Performance, Max, Smart
-- Rule engine (priority-based):
-  - Example: `IF maxTemp >= 55 THEN set max fan until <= 65`
-- Sleep/wake command re-apply via daemon
-- Heartbeat watchdog resets fans if app dies
-- Structured event logging (`jsonl`) + rotating plain logs
+## Release
+
+Current fork release: **`v0.2.0`**
+
+- Release page: <https://github.com/d37atm/ThermalForge/releases/tag/v0.2.0>
+- Artifacts:
+  - `ThermalForge-v0.2.0-macos-arm64-app.zip`
+  - `ThermalForge-v0.2.0-macos-arm64-cli.tar.gz`
+  - `checksums.txt`
+
+`v0.2.0` adds:
+- typed daemon protocol (`DaemonRequest` / `DaemonResponse`) with legacy command fallback
+- rule engine (IF/THEN with priority + latch/until)
+- extracted control state machine + service
+- unified built-in profiles (Smart included)
+- structured event logging + expanded tests
+- hardened app bundle/release pipeline
+
+## Architecture
+
+`ThermalForgeCore` is split into explicit layers:
+
+1. **Hardware**
+- SMC adapter (`FanControl`)
+- test seams: `FanController`, `SensorProvider`
+
+2. **Control**
+- `ThermalMonitor` runtime loop
+- `ControlService`, `ControlStateMachine`
+- `RuleEngine`, `RulePersistence`
+
+3. **Transport**
+- daemon socket: `/var/run/thermalforge.sock`
+- protocol: `DaemonRequest`, `DaemonResponse`, `DaemonCodec`
+
+4. **Observability**
+- rotating text logs (`~/Library/Logs/ThermalForge`)
+- structured events (`thermalforge-events-YYYY-MM-DD.jsonl`)
+- research logger (`thermalforge log`)
+
+## Safety Model
+
+Execution precedence:
+1. hard safety override (`>=95°C` -> max fan)
+2. rule engine decisions
+3. profile curve logic
+
+Daemon boundary:
+- launchd system daemon (`root`)
+- local Unix socket with restrictive permissions
+- peer UID authorization (root or active console user)
+- heartbeat watchdog resets fans if client disappears
+
+## Profiles
+
+Built-in:
+- `silent`
+- `balanced`
+- `performance`
+- `max`
+- `smart`
+
+Control loop:
+- thermal cadence: 100ms
+- monitor cadence: 2s
+- UI cadence: 500ms
+
+## Rules (IF/THEN)
+
+Rules are persisted at:
+- `~/Library/Application Support/ThermalForge/rules.json`
+
+CLI:
+```bash
+thermalforge rules list
+thermalforge rules add --trigger 55 --until 65 --max
+thermalforge rules enable <rule-id>
+thermalforge rules disable <rule-id>
+thermalforge rules remove <rule-id>
+thermalforge rules test --cpu 70 --gpu 62 --profile balanced
+```
 
 ## Install
 
 ### Homebrew
-
 ```bash
 brew install ProducerGuy/tap/thermalforge
 sudo thermalforge install
 ```
 
-### From Source
-
+### Source
 ```bash
-git clone https://github.com/ProducerGuy/ThermalForge.git
+git clone https://github.com/d37atm/ThermalForge.git
 cd ThermalForge
 ./setup.sh
 ```
 
-`setup.sh` now uses a hardened app-bundle builder:
-- `Scripts/build-app-bundle.sh`
-- validated `Info.plist`
-- executable permission checks
-- ad-hoc signing + quarantine cleanup
-
-## Run
-
+Open app:
 ```bash
 open /Applications/ThermalForge.app
 ```
 
-## CLI
+## Build / Test
+
+```bash
+swift build
+swift test
+./Scripts/ci-smoke.sh
+```
+
+Release build scripts:
+- `Scripts/version.sh`
+- `Scripts/build-app-bundle.sh`
+- `Scripts/ci-smoke.sh`
+
+CI workflows:
+- `.github/workflows/ci.yml` (build + test + package smoke)
+- `.github/workflows/release.yml` (tag-based artifact release)
+
+## CLI Quick Reference
 
 ```bash
 thermalforge status
@@ -58,43 +140,19 @@ thermalforge discover
 thermalforge log --rate 10 --duration 1h --no-expire
 ```
 
-### Rules CLI
+## Troubleshooting
 
+If macOS blocks the app after download:
 ```bash
-thermalforge rules list
-thermalforge rules add --trigger 55 --until 65 --max
-thermalforge rules enable <rule-id>
-thermalforge rules disable <rule-id>
-thermalforge rules remove <rule-id>
-thermalforge rules test --cpu 70 --gpu 62 --profile balanced
+xattr -dr com.apple.quarantine /Applications/ThermalForge.app
+codesign --force --deep --sign - /Applications/ThermalForge.app
+open /Applications/ThermalForge.app
 ```
 
-## Safety
-
-- Hard override: any sensor >= 95°C -> max fan
-- Hysteresis + sustained triggers reduce oscillation
-- Daemon authorization: root or active console user only
-- Socket: `/var/run/thermalforge.sock` with restrictive perms
-
-## Development
-
+Reset fans immediately:
 ```bash
-swift build
-swift test
-./Scripts/ci-smoke.sh
+thermalforge auto
 ```
-
-CI workflows:
-- `.github/workflows/ci.yml`: build + tests + package smoke
-- `.github/workflows/release.yml`: release artifact packaging
-
-## Uninstall
-
-```bash
-sudo thermalforge uninstall
-```
-
-Removes daemon, CLI, app bundle, and ThermalForge user data/logs.
 
 ## License
 

--- a/Scripts/build-app-bundle.sh
+++ b/Scripts/build-app-bundle.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT_DIR/Scripts/version.sh"
+
+APP_PATH="${1:-/Applications/ThermalForge.app}"
+APP_CONTENTS="$APP_PATH/Contents"
+APP_BIN="$ROOT_DIR/.build/release/ThermalForgeApp"
+ICON_PATH="$ROOT_DIR/ThermalForge.icns"
+
+mkdir -p "$APP_CONTENTS/MacOS" "$APP_CONTENTS/Resources"
+cp "$APP_BIN" "$APP_CONTENTS/MacOS/ThermalForgeApp"
+chmod +x "$APP_CONTENTS/MacOS/ThermalForgeApp"
+
+if [ -f "$ICON_PATH" ]; then
+  cp "$ICON_PATH" "$APP_CONTENTS/Resources/AppIcon.icns"
+fi
+
+cat > "$APP_CONTENTS/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>ThermalForge</string>
+  <key>CFBundleDisplayName</key><string>ThermalForge</string>
+  <key>CFBundleIdentifier</key><string>com.thermalforge.app</string>
+  <key>CFBundleVersion</key><string>${THERMALFORGE_VERSION}</string>
+  <key>CFBundleShortVersionString</key><string>${THERMALFORGE_VERSION}</string>
+  <key>CFBundleExecutable</key><string>ThermalForgeApp</string>
+  <key>CFBundleIconFile</key><string>AppIcon</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>LSMinimumSystemVersion</key><string>14.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>
+PLIST
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - "$APP_PATH" >/dev/null 2>&1 || true
+fi
+
+xattr -cr "$APP_PATH" || true
+plutil -lint "$APP_CONTENTS/Info.plist" >/dev/null

--- a/Scripts/ci-smoke.sh
+++ b/Scripts/ci-smoke.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$ROOT_DIR"
+swift build -c release
+
+SMOKE_APP="$ROOT_DIR/.build/ThermalForge-smoke.app"
+rm -rf "$SMOKE_APP"
+"$ROOT_DIR/Scripts/build-app-bundle.sh" "$SMOKE_APP"
+plutil -lint "$SMOKE_APP/Contents/Info.plist" >/dev/null
+
+echo "CI smoke checks passed."

--- a/Scripts/version.sh
+++ b/Scripts/version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Single source of truth is ThermalForgeVersion.current in Swift source.
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION_FILE="$ROOT_DIR/Sources/ThermalForgeCore/ThermalForgeVersion.swift"
+
+THERMALFORGE_VERSION="$(
+  grep -Eo 'current = "[0-9]+\.[0-9]+\.[0-9]+"' "$VERSION_FILE" \
+    | head -n1 \
+    | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/'
+)"
+
+if [ -z "${THERMALFORGE_VERSION:-}" ]; then
+  echo "Failed to extract THERMALFORGE_VERSION from $VERSION_FILE" >&2
+  exit 1
+fi
+
+export THERMALFORGE_VERSION

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -15,11 +15,27 @@ final class AppState: ObservableObject {
     @Published var activeProfile: FanProfile = .silent
     @Published var monitorState: MonitorState = .idle
     @Published var maxTemp: Float?
+
     @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
         didSet { UserDefaults.standard.set(useFahrenheit, forKey: "useFahrenheit") }
     }
+
     @Published var launchAtLogin: Bool = false {
         didSet { updateLoginItem() }
+    }
+
+    @Published var rulesEnabled: Bool = UserDefaults.standard.object(forKey: "rulesEnabled") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(rulesEnabled, forKey: "rulesEnabled")
+            pushRulesToMonitor()
+        }
+    }
+
+    @Published var rules: [ThermalRule] = [] {
+        didSet {
+            persistRules()
+            pushRulesToMonitor()
+        }
     }
 
     private var monitor: ThermalMonitor?
@@ -33,8 +49,10 @@ final class AppState: ObservableObject {
         try? executor.execute(.resetAuto)
         TFLogger.shared.info("App launched — fans reset to auto")
 
-        // Clean expired logs
+        // Clean expired logs.
         ThermalLogger.cleanExpired()
+
+        rules = RulePersistence.load()
 
         startMonitoring()
         startHeartbeat()
@@ -47,9 +65,12 @@ final class AppState: ObservableObject {
     // MARK: - Heartbeat
 
     private func startHeartbeat() {
-        let client = DaemonClient()
-        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
-            _ = try? client.send("heartbeat")
+        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            do {
+                try self?.executor.heartbeat()
+            } catch {
+                TFLogger.shared.error("Heartbeat failed: \(error)")
+            }
         }
     }
 
@@ -58,35 +79,48 @@ final class AppState: ObservableObject {
     func startMonitoring() {
         guard let fc = try? FanControl() else { return }
 
-        let monitor = ThermalMonitor(fanControl: fc, profile: activeProfile)
+        let ruleEngine = RuleEngine(rules: rules, isEnabled: rulesEnabled)
+        let controlService = ControlService(ruleEngine: ruleEngine)
+        let monitor = ThermalMonitor(fanControl: fc, profile: activeProfile, controlService: controlService)
+
         monitor.onUpdate = { [weak self] status, profile, state in
             Task { @MainActor [weak self] in
                 self?.latestStatus = status
                 self?.activeProfile = profile
                 self?.monitorState = state
-                // Max of only the displayed sensors
-                // Peak across all CPU and GPU sensors for menu bar display
                 let displayPrefixes = ["TC", "Tp", "TG", "Tg"]
                 self?.maxTemp = status.temperatures
                     .filter { key, _ in displayPrefixes.contains(where: { key.hasPrefix($0) }) }
                     .values.max()
             }
         }
+
         monitor.onFanCommand = { [weak self] command in
             Task { @MainActor [weak self] in
                 try self?.executor.execute(command)
             }
         }
+
         monitor.start()
         self.monitor = monitor
+    }
+
+    private func pushRulesToMonitor() {
+        monitor?.updateRules(rules, enabled: rulesEnabled)
+    }
+
+    private func persistRules() {
+        do {
+            try RulePersistence.save(rules)
+        } catch {
+            TFLogger.shared.error("Failed to persist rules: \(error)")
+        }
     }
 
     // MARK: - Actions
 
     func setSmart() {
-        activeProfile = .smart
-        monitor?.switchProfile(.smart)
-        TFLogger.shared.profile("Smart activated")
+        selectProfile(.smart)
     }
 
     func resetAuto() {
@@ -105,17 +139,39 @@ final class AppState: ObservableObject {
         monitor?.switchProfile(profile)
         TFLogger.shared.profile("Selected: \(profile.name)")
 
-        // All profiles use proportional curves — tick() handles fan engagement.
-        // Reset to auto on profile change so tick() starts from a clean state.
         do {
-            if profile.curve.handsOff || profile.id == "smart" || profile.id == "silent" {
+            if profile.curve.handsOff || profile.id == "silent" {
                 try executor.execute(.resetAuto)
             }
-            // Balanced/Performance/Max: tick() will ramp proportionally
-            // based on current temperature after sustained trigger is met
         } catch {
             TFLogger.shared.error("Profile \(profile.name) failed: \(error)")
         }
+    }
+
+    func addQuickRule() {
+        let rule = ThermalRule(
+            name: "IF temp ≥ 55°C THEN 100% until ≤ 65°C",
+            enabled: true,
+            priority: 900,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 55),
+            action: .setMax,
+            untilTempBelowC: 65
+        )
+        rules.append(rule)
+    }
+
+    func removeRule(_ id: String) {
+        rules.removeAll(where: { $0.id == id })
+    }
+
+    func toggleRule(_ id: String, enabled: Bool) {
+        guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
+        rules[idx].enabled = enabled
+    }
+
+    func moveRule(_ id: String, toPriority priority: Int) {
+        guard let idx = rules.firstIndex(where: { $0.id == id }) else { return }
+        rules[idx].priority = priority
     }
 
     // MARK: - Launch at Login
@@ -129,7 +185,7 @@ final class AppState: ObservableObject {
             }
         } catch {
             TFLogger.shared.error("Launch at login toggle failed: \(error)")
-            launchAtLogin = !launchAtLogin // revert toggle
+            launchAtLogin = !launchAtLogin
         }
     }
 }

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -75,7 +75,6 @@ struct MenuBarView: View {
                         if !profile.curve.handsOff {
                             let unit = appState.useFahrenheit ? "F" : "C"
                             if profile.curve.instantEngage {
-                                // Max: show instant trigger temp
                                 let startC = profile.curve.startTemp
                                 let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
                                 Text("\(Int(startDisp))°\(unit) instant")
@@ -98,6 +97,40 @@ struct MenuBarView: View {
             .pickerStyle(.inline)
             .labelsHidden()
             .padding(.horizontal, 12)
+
+            Divider().padding(.vertical, 4)
+
+            SectionHeader(title: "RULES")
+            Toggle("Enable Rule Engine", isOn: $appState.rulesEnabled)
+                .padding(.horizontal, 12)
+
+            if appState.rules.isEmpty {
+                Text("No rules configured")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+            } else {
+                ForEach(appState.rules.sorted(by: { $0.priority > $1.priority })) { rule in
+                    HStack {
+                        Toggle(rule.name, isOn: ruleBinding(rule.id))
+                        Button(action: { appState.removeRule(rule.id) }) {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 1)
+                }
+            }
+
+            Button(action: { appState.addQuickRule() }) {
+                Label("Add IF/THEN Rule", systemImage: "plus.circle")
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 12)
+            .padding(.top, 2)
 
             Divider().padding(.vertical, 4)
 
@@ -135,7 +168,7 @@ struct MenuBarView: View {
             .padding(.top, 4)
             .padding(.bottom, 10)
         }
-        .frame(width: 260)
+        .frame(width: 320)
     }
 
     // MARK: - Helpers
@@ -162,6 +195,17 @@ struct MenuBarView: View {
         guard let temps = appState.latestStatus?.temperatures else { return nil }
         let values = temps.filter { key, _ in prefixes.contains(where: { key.hasPrefix($0) }) }.values
         return values.max()
+    }
+
+    private func ruleBinding(_ ruleID: String) -> Binding<Bool> {
+        Binding(
+            get: {
+                appState.rules.first(where: { $0.id == ruleID })?.enabled ?? false
+            },
+            set: { enabled in
+                appState.toggleRule(ruleID, enabled: enabled)
+            }
+        )
     }
 }
 

--- a/Sources/ThermalForgeApp/PrivilegedExecutor.swift
+++ b/Sources/ThermalForgeApp/PrivilegedExecutor.swift
@@ -16,6 +16,10 @@ final class PrivilegedExecutor: @unchecked Sendable {
         try client.execute(command)
     }
 
+    func heartbeat() throws {
+        try client.heartbeat()
+    }
+
     var isDaemonRunning: Bool {
         ThermalForgeDaemon.isRunning
     }

--- a/Sources/ThermalForgeCore/Control/ControlService.swift
+++ b/Sources/ThermalForgeCore/Control/ControlService.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public struct RuleEvaluationContext: Equatable {
+    public let cpuTemp: Float
+    public let gpuTemp: Float
+    public let maxTemp: Float
+    public let profileID: String
+
+    public init(cpuTemp: Float, gpuTemp: Float, maxTemp: Float, profileID: String) {
+        self.cpuTemp = cpuTemp
+        self.gpuTemp = gpuTemp
+        self.maxTemp = maxTemp
+        self.profileID = profileID
+    }
+}
+
+public struct RuleDecision: Equatable {
+    public let command: FanCommand?
+    public let profileID: String?
+    public let sourceRuleID: String
+    public let sourceRuleName: String
+
+    public init(command: FanCommand?, profileID: String?, sourceRuleID: String, sourceRuleName: String) {
+        self.command = command
+        self.profileID = profileID
+        self.sourceRuleID = sourceRuleID
+        self.sourceRuleName = sourceRuleName
+    }
+}
+
+public final class ControlService {
+    private var stateMachine = ControlStateMachine()
+    public private(set) var ruleEngine: RuleEngine
+
+    public init(ruleEngine: RuleEngine = RuleEngine()) {
+        self.ruleEngine = ruleEngine
+    }
+
+    public func replaceRules(_ rules: [ThermalRule], enabled: Bool) {
+        ruleEngine.setRules(rules)
+        ruleEngine.isEnabled = enabled
+    }
+
+    public func evaluateRules(context: RuleEvaluationContext) -> RuleDecision? {
+        ruleEngine.evaluate(context: context)
+    }
+
+    @discardableResult
+    public func transition(_ event: ControlEvent) -> MonitorState {
+        stateMachine.transition(event)
+    }
+
+    public func currentState() -> MonitorState {
+        stateMachine.state
+    }
+}

--- a/Sources/ThermalForgeCore/Control/ControlStateMachine.swift
+++ b/Sources/ThermalForgeCore/Control/ControlStateMachine.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public enum ControlEvent: Equatable {
+    case idle
+    case profileActive(String)
+    case safetyTriggered
+    case safetyCleared
+}
+
+public struct ControlStateMachine {
+    public private(set) var state: MonitorState = .idle
+
+    public init(initialState: MonitorState = .idle) {
+        self.state = initialState
+    }
+
+    @discardableResult
+    public mutating func transition(_ event: ControlEvent) -> MonitorState {
+        switch event {
+        case .idle:
+            state = .idle
+        case .profileActive(let profileName):
+            state = .active(profileName: profileName)
+        case .safetyTriggered:
+            state = .safetyOverride
+        case .safetyCleared:
+            if state == .safetyOverride {
+                state = .idle
+            }
+        }
+        return state
+    }
+}

--- a/Sources/ThermalForgeCore/Control/RuleEngine.swift
+++ b/Sources/ThermalForgeCore/Control/RuleEngine.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+public final class RuleEngine {
+    public var isEnabled: Bool
+    private var rules: [ThermalRule]
+    private var latchedRuleID: String?
+
+    public init(rules: [ThermalRule] = [], isEnabled: Bool = true) {
+        self.rules = rules
+        self.isEnabled = isEnabled
+    }
+
+    public func setRules(_ rules: [ThermalRule]) {
+        self.rules = rules
+        if let latchedRuleID,
+           !rules.contains(where: { $0.id == latchedRuleID && $0.enabled })
+        {
+            self.latchedRuleID = nil
+        }
+    }
+
+    public func allRules() -> [ThermalRule] {
+        rules.sorted { lhs, rhs in
+            if lhs.priority == rhs.priority {
+                return lhs.name < rhs.name
+            }
+            return lhs.priority > rhs.priority
+        }
+    }
+
+    public func evaluate(context: RuleEvaluationContext) -> RuleDecision? {
+        guard isEnabled else {
+            latchedRuleID = nil
+            return nil
+        }
+
+        if let latched = resolveLatchedRule(context: context) {
+            return latched
+        }
+
+        let sorted = allRules().filter { $0.enabled }
+        for rule in sorted where matches(rule: rule, context: context) {
+            if rule.untilTempBelowC != nil {
+                latchedRuleID = rule.id
+            }
+            return makeDecision(rule: rule)
+        }
+        return nil
+    }
+
+    private func resolveLatchedRule(context: RuleEvaluationContext) -> RuleDecision? {
+        guard let latchedRuleID,
+              let rule = rules.first(where: { $0.id == latchedRuleID && $0.enabled })
+        else {
+            self.latchedRuleID = nil
+            return nil
+        }
+
+        if let until = rule.untilTempBelowC {
+            if context.maxTemp > until {
+                return makeDecision(rule: rule)
+            }
+            self.latchedRuleID = nil
+            return nil
+        }
+
+        self.latchedRuleID = nil
+        return nil
+    }
+
+    private func matches(rule: ThermalRule, context: RuleEvaluationContext) -> Bool {
+        let current: Float
+        switch rule.condition.metric {
+        case .maxTemp:
+            current = context.maxTemp
+        case .cpuTemp:
+            current = context.cpuTemp
+        case .gpuTemp:
+            current = context.gpuTemp
+        }
+        return rule.condition.comparator.evaluate(lhs: current, rhs: rule.condition.valueCelsius)
+    }
+
+    private func makeDecision(rule: ThermalRule) -> RuleDecision {
+        let command: FanCommand?
+        let profileID: String?
+
+        switch rule.action {
+        case .setMax:
+            command = .setMax
+            profileID = nil
+        case .setRPM(let rpm):
+            command = .setRPM(Float(rpm))
+            profileID = nil
+        case .resetAuto:
+            command = .resetAuto
+            profileID = nil
+        case .selectProfile(let id):
+            command = nil
+            profileID = id
+        }
+
+        return RuleDecision(
+            command: command,
+            profileID: profileID,
+            sourceRuleID: rule.id,
+            sourceRuleName: rule.name
+        )
+    }
+}

--- a/Sources/ThermalForgeCore/Control/RuleModel.swift
+++ b/Sources/ThermalForgeCore/Control/RuleModel.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public enum ThermalMetric: String, Codable, CaseIterable {
+    case maxTemp
+    case cpuTemp
+    case gpuTemp
+}
+
+public enum RuleComparator: String, Codable, CaseIterable {
+    case greaterThan = ">"
+    case greaterThanOrEqual = ">="
+    case lessThan = "<"
+    case lessThanOrEqual = "<="
+
+    public func evaluate(lhs: Float, rhs: Float) -> Bool {
+        switch self {
+        case .greaterThan: return lhs > rhs
+        case .greaterThanOrEqual: return lhs >= rhs
+        case .lessThan: return lhs < rhs
+        case .lessThanOrEqual: return lhs <= rhs
+        }
+    }
+}
+
+public enum ThermalRuleAction: Codable, Equatable {
+    case setMax
+    case setRPM(Int)
+    case resetAuto
+    case selectProfile(String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case rpm
+        case profileID
+    }
+
+    private enum ActionType: String, Codable {
+        case setMax
+        case setRPM
+        case resetAuto
+        case selectProfile
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(ActionType.self, forKey: .type)
+        switch type {
+        case .setMax:
+            self = .setMax
+        case .setRPM:
+            self = .setRPM(try c.decode(Int.self, forKey: .rpm))
+        case .resetAuto:
+            self = .resetAuto
+        case .selectProfile:
+            self = .selectProfile(try c.decode(String.self, forKey: .profileID))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .setMax:
+            try c.encode(ActionType.setMax, forKey: .type)
+        case .setRPM(let rpm):
+            try c.encode(ActionType.setRPM, forKey: .type)
+            try c.encode(rpm, forKey: .rpm)
+        case .resetAuto:
+            try c.encode(ActionType.resetAuto, forKey: .type)
+        case .selectProfile(let profileID):
+            try c.encode(ActionType.selectProfile, forKey: .type)
+            try c.encode(profileID, forKey: .profileID)
+        }
+    }
+}
+
+public struct ThermalRuleCondition: Codable, Equatable {
+    public let metric: ThermalMetric
+    public let comparator: RuleComparator
+    public let valueCelsius: Float
+
+    public init(metric: ThermalMetric, comparator: RuleComparator, valueCelsius: Float) {
+        self.metric = metric
+        self.comparator = comparator
+        self.valueCelsius = valueCelsius
+    }
+}
+
+public struct ThermalRule: Codable, Equatable, Identifiable {
+    public let id: String
+    public var name: String
+    public var enabled: Bool
+    /// Higher number means higher priority.
+    public var priority: Int
+    public var condition: ThermalRuleCondition
+    public var action: ThermalRuleAction
+    /// Optional latch release threshold. If set, rule remains active until maxTemp drops below this value.
+    public var untilTempBelowC: Float?
+
+    public init(
+        id: String = UUID().uuidString,
+        name: String,
+        enabled: Bool = true,
+        priority: Int = 100,
+        condition: ThermalRuleCondition,
+        action: ThermalRuleAction,
+        untilTempBelowC: Float? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.enabled = enabled
+        self.priority = priority
+        self.condition = condition
+        self.action = action
+        self.untilTempBelowC = untilTempBelowC
+    }
+}

--- a/Sources/ThermalForgeCore/Control/RulePersistence.swift
+++ b/Sources/ThermalForgeCore/Control/RulePersistence.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum RulePersistence {
+    public static var filePath: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/ThermalForge/rules.json")
+    }
+
+    public static func load() -> [ThermalRule] {
+        guard FileManager.default.fileExists(atPath: filePath.path) else { return [] }
+        guard let data = try? Data(contentsOf: filePath) else { return [] }
+        return (try? JSONDecoder().decode([ThermalRule].self, from: data)) ?? []
+    }
+
+    public static func save(_ rules: [ThermalRule]) throws {
+        let dir = filePath.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(rules)
+        try data.write(to: filePath)
+    }
+}

--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -13,7 +13,7 @@ import IOKit.pwr_mgt
 // MARK: - Constants
 
 public enum ThermalForgeDaemon {
-    public static let socketPath = "/tmp/thermalforge.sock"
+    public static let socketPath = "/var/run/thermalforge.sock"
     public static let plistPath = "/Library/LaunchDaemons/com.thermalforge.daemon.plist"
     public static let installPath = "/usr/local/bin/thermalforge"
     public static let label = "com.thermalforge.daemon"
@@ -123,9 +123,11 @@ public final class DaemonServer {
     /// Heartbeat: last time the app checked in
     private var lastHeartbeat: Date?
     private let heartbeatLock = NSLock()
+    private let authorizedUID: uid_t?
 
     public init(fanControl: FanControl) throws {
         self.fanControl = fanControl
+        self.authorizedUID = currentConsoleUID()
 
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
@@ -150,8 +152,14 @@ public final class DaemonServer {
             throw ThermalForgeError.writeFailed("bind() failed: \(errno)")
         }
 
-        // Allow all local users to connect
-        chmod(ThermalForgeDaemon.socketPath, 0o777)
+        // Restrict socket access to root + active console user.
+        if let uid = authorizedUID {
+            _ = chown(ThermalForgeDaemon.socketPath, uid, 0)
+            chmod(ThermalForgeDaemon.socketPath, 0o600)
+        } else {
+            // Fallback: root-only if no console user is available.
+            chmod(ThermalForgeDaemon.socketPath, 0o600)
+        }
 
         guard listen(fd, 5) == 0 else {
             close(fd)
@@ -298,6 +306,15 @@ public final class DaemonServer {
     }
 
     private func handleClient(_ fd: Int32) {
+        guard isAuthorizedClient(fd) else {
+            NSLog("ThermalForge daemon: rejected unauthorized client")
+            let responseBytes = Array("error: unauthorized client\n".utf8)
+            _ = responseBytes.withUnsafeBufferPointer { buf in
+                write(fd, buf.baseAddress!, buf.count)
+            }
+            return
+        }
+
         var buffer = [UInt8](repeating: 0, count: 256)
         let n = read(fd, &buffer, buffer.count - 1)
         guard n > 0 else { return }
@@ -362,6 +379,18 @@ public final class DaemonServer {
         }
     }
 
+    private func isAuthorizedClient(_ fd: Int32) -> Bool {
+        var peerUID: uid_t = 0
+        var peerGID: gid_t = 0
+        guard getpeereid(fd, &peerUID, &peerGID) == 0 else {
+            return false
+        }
+
+        if peerUID == 0 { return true }
+        guard let authorizedUID else { return false }
+        return peerUID == authorizedUID
+    }
+
     deinit {
         close(socketFD)
         unlink(ThermalForgeDaemon.socketPath)
@@ -369,6 +398,13 @@ public final class DaemonServer {
 }
 
 // MARK: - Helpers
+
+private func currentConsoleUID() -> uid_t? {
+    var st = stat()
+    guard stat("/dev/console", &st) == 0 else { return nil }
+    guard st.st_uid != 0 else { return nil }
+    return st.st_uid
+}
 
 /// Copy a path string into sockaddr_un.sun_path
 private func setPath(_ addr: inout sockaddr_un, _ path: String) {

--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -18,7 +18,7 @@ public enum ThermalForgeDaemon {
     public static let installPath = "/usr/local/bin/thermalforge"
     public static let label = "com.thermalforge.daemon"
 
-    /// Check if the daemon socket exists and accepts connections
+    /// Check if the daemon socket exists and accepts connections.
     public static var isRunning: Bool {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { return false }
@@ -42,7 +42,8 @@ public enum ThermalForgeDaemon {
 public enum DaemonError: Error, CustomStringConvertible {
     case notRunning
     case connectionFailed
-    case commandFailed(String)
+    case protocolError(String)
+    case commandFailed(code: String, message: String)
 
     public var description: String {
         switch self {
@@ -50,8 +51,10 @@ public enum DaemonError: Error, CustomStringConvertible {
             return "ThermalForge daemon is not running. Run: sudo thermalforge install"
         case .connectionFailed:
             return "Failed to connect to daemon socket"
-        case .commandFailed(let msg):
-            return "Daemon error: \(msg)"
+        case .protocolError(let msg):
+            return "Daemon protocol error: \(msg)"
+        case .commandFailed(let code, let message):
+            return "Daemon error [\(code)]: \(message)"
         }
     }
 }
@@ -59,8 +62,25 @@ public enum DaemonError: Error, CustomStringConvertible {
 public final class DaemonClient {
     public init() {}
 
-    /// Send a command to the daemon and return the response
+    /// Backward-compatible string command transport.
     public func send(_ command: String) throws -> String {
+        let request = try legacyCommandToRequest(command)
+        let response = try send(request)
+        if response.ok {
+            if let status = response.status {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                encoder.keyEncodingStrategy = .convertToSnakeCase
+                let data = try encoder.encode(status)
+                return String(data: data, encoding: .utf8) ?? "{}"
+            }
+            return response.message ?? "ok"
+        }
+        let err = response.error ?? DaemonErrorPayload(code: "daemon_error", message: response.message ?? "unknown")
+        throw DaemonError.commandFailed(code: err.code, message: err.message)
+    }
+
+    public func send(_ request: DaemonRequest) throws -> DaemonResponse {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw DaemonError.connectionFailed }
         defer { close(fd) }
@@ -76,38 +96,81 @@ public final class DaemonClient {
         }
         guard connectResult == 0 else { throw DaemonError.notRunning }
 
-        // Send command
-        let cmdData = Array((command + "\n").utf8)
-        _ = cmdData.withUnsafeBufferPointer { buf in
+        let payload = try DaemonCodec.encodeRequest(request)
+        let bytes = [UInt8](payload + [0x0A])
+        _ = bytes.withUnsafeBufferPointer { buf in
             write(fd, buf.baseAddress!, buf.count)
         }
 
-        // Read response — 8KB handles status JSON on sensor-rich machines
-        var buffer = [UInt8](repeating: 0, count: 8192)
+        var buffer = [UInt8](repeating: 0, count: 65536)
         let n = read(fd, &buffer, buffer.count - 1)
         guard n > 0 else { throw DaemonError.connectionFailed }
 
-        let response = String(bytes: buffer[0..<n], encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-        if response.hasPrefix("error:") {
-            throw DaemonError.commandFailed(
-                String(response.dropFirst(6)).trimmingCharacters(in: .whitespaces)
-            )
+        let responseData = Data(buffer[0..<n])
+        if let typedResponse = try? DaemonCodec.decodeResponse(responseData) {
+            return typedResponse
         }
 
-        return response
+        // Fallback for old daemon responses.
+        let fallback = String(decoding: responseData, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        if fallback.hasPrefix("error:") {
+            throw DaemonError.commandFailed(code: "legacy_error", message: String(fallback.dropFirst(6)).trimmingCharacters(in: .whitespaces))
+        }
+        return DaemonResponse(requestID: request.requestID, ok: true, message: fallback)
     }
 
-    /// Send a FanCommand to the daemon
     public func execute(_ command: FanCommand) throws {
-        let cmdString: String
+        let req: DaemonRequest
         switch command {
-        case .setMax: cmdString = "max"
-        case .setRPM(let rpm): cmdString = "set \(Int(rpm))"
-        case .resetAuto: cmdString = "auto"
+        case .setMax:
+            req = DaemonRequest(command: "max")
+        case .setRPM(let rpm):
+            req = DaemonRequest(command: "set", rpm: Int(rpm))
+        case .resetAuto:
+            req = DaemonRequest(command: "auto")
         }
-        _ = try send(cmdString)
+        let response = try send(req)
+        if !response.ok {
+            let err = response.error ?? DaemonErrorPayload(code: "daemon_error", message: response.message ?? "unknown")
+            throw DaemonError.commandFailed(code: err.code, message: err.message)
+        }
+    }
+
+    public func heartbeat() throws {
+        let response = try send(DaemonRequest(command: "heartbeat"))
+        if !response.ok {
+            let err = response.error ?? DaemonErrorPayload(code: "daemon_error", message: response.message ?? "unknown")
+            throw DaemonError.commandFailed(code: err.code, message: err.message)
+        }
+    }
+
+    public func fetchRules() throws -> [ThermalRule] {
+        let response = try send(DaemonRequest(command: "rules.list"))
+        if !response.ok {
+            let err = response.error ?? DaemonErrorPayload(code: "daemon_error", message: response.message ?? "unknown")
+            throw DaemonError.commandFailed(code: err.code, message: err.message)
+        }
+        return response.rules ?? []
+    }
+
+    private func legacyCommandToRequest(_ command: String) throws -> DaemonRequest {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: " ")
+        guard let first = parts.first.map(String.init) else {
+            throw DaemonError.protocolError("empty command")
+        }
+
+        switch first {
+        case "max", "auto", "status", "heartbeat":
+            return DaemonRequest(command: first)
+        case "set":
+            guard parts.count >= 2, let rpm = Int(parts[1]) else {
+                throw DaemonError.protocolError("usage: set <rpm>")
+            }
+            return DaemonRequest(command: "set", rpm: rpm)
+        default:
+            return DaemonRequest(command: first)
+        }
     }
 }
 
@@ -116,11 +179,12 @@ public final class DaemonClient {
 public final class DaemonServer {
     private let socketFD: Int32
     private let fanControl: FanControl
-    /// Serializes all SMC access — prevents data race between client handler and watchdog
+
+    /// Serializes all SMC access — prevents data race between client handler and watchdog.
     private let smcLock = NSLock()
-    /// Last fan command — re-applied after sleep/wake
-    private var lastCommand: String?
-    /// Heartbeat: last time the app checked in
+    /// Last fan command — re-applied after sleep/wake.
+    private var lastCommand: FanCommand?
+    /// Heartbeat: last time the app checked in.
     private var lastHeartbeat: Date?
     private let heartbeatLock = NSLock()
     private let authorizedUID: uid_t?
@@ -135,7 +199,6 @@ public final class DaemonServer {
         }
         self.socketFD = fd
 
-        // Remove stale socket
         unlink(ThermalForgeDaemon.socketPath)
 
         var addr = sockaddr_un()
@@ -152,12 +215,10 @@ public final class DaemonServer {
             throw ThermalForgeError.writeFailed("bind() failed: \(errno)")
         }
 
-        // Restrict socket access to root + active console user.
         if let uid = authorizedUID {
             _ = chown(ThermalForgeDaemon.socketPath, uid, 0)
             chmod(ThermalForgeDaemon.socketPath, 0o600)
         } else {
-            // Fallback: root-only if no console user is available.
             chmod(ThermalForgeDaemon.socketPath, 0o600)
         }
 
@@ -167,19 +228,13 @@ public final class DaemonServer {
         }
     }
 
-    /// Run the server loop (blocks forever)
+    /// Run the server loop (blocks forever).
     public func run() {
         NSLog("ThermalForge daemon: listening on %@", ThermalForgeDaemon.socketPath)
 
-        // Watch for sleep/wake to re-apply fan settings
         registerWakeNotification()
-
-        // Heartbeat watchdog: if app set fans to manual but hasn't checked in
-        // for 15 seconds, reset to auto. Prevents fans stuck after app crash.
         startHeartbeatWatchdog()
 
-        // Accept connections on a background thread
-        // (RunLoop.main needed for NSWorkspace notifications)
         DispatchQueue.global(qos: .utility).async { [self] in
             while true {
                 let clientFD = accept(socketFD, nil, nil)
@@ -189,7 +244,6 @@ public final class DaemonServer {
             }
         }
 
-        // Main thread runs the RunLoop for wake notifications
         RunLoop.main.run()
     }
 
@@ -205,8 +259,6 @@ public final class DaemonServer {
                 let hasManualControl = lastCommand != nil
                 heartbeatLock.unlock()
 
-                // Only reset if: app has connected before (lastBeat != nil),
-                // fans are in manual mode, and heartbeat is stale
                 guard let beat = lastBeat, hasManualControl else { continue }
 
                 if Date().timeIntervalSince(beat) > 15 {
@@ -222,7 +274,6 @@ public final class DaemonServer {
                     }
                     smcLock.unlock()
 
-                    // Only clear state if reset actually worked — otherwise retry next cycle
                     if resetSucceeded {
                         heartbeatLock.lock()
                         lastCommand = nil
@@ -236,7 +287,6 @@ public final class DaemonServer {
 
     // MARK: - Sleep/Wake
 
-    /// IOKit root port for power notifications
     private var rootPort: io_connect_t = 0
     private var notifyPort: IONotificationPortRef?
     private var notifier: io_object_t = 0
@@ -248,7 +298,6 @@ public final class DaemonServer {
                 guard let refcon = refcon else { return }
                 let server = Unmanaged<DaemonServer>.fromOpaque(refcon).takeUnretainedValue()
 
-                // IOKit message constants (macros unavailable in Swift)
                 let kSystemHasPoweredOn: UInt32 = 0xe0000300
                 let kSystemWillSleep: UInt32 = 0xe0000280
                 let kCanSystemSleep: UInt32 = 0xe0000270
@@ -280,23 +329,19 @@ public final class DaemonServer {
             return
         }
 
-        NSLog("ThermalForge daemon: woke — re-applying: %@", command)
+        NSLog("ThermalForge daemon: woke — re-applying previous fan command")
 
-        // Delay slightly — SMC needs a moment after wake
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2.0) { [self] in
             smcLock.lock()
             defer { smcLock.unlock() }
-            let parts = command.split(separator: " ")
             do {
-                switch parts.first.map(String.init) {
-                case "max":
+                switch command {
+                case .setMax:
                     try fanControl.setMax()
-                case "set":
-                    if let rpm = parts.dropFirst().first.flatMap({ Float($0) }) {
-                        try fanControl.setAllFans(rpm: rpm)
-                    }
-                default:
-                    break
+                case .setRPM(let rpm):
+                    try fanControl.setAllFans(rpm: rpm)
+                case .resetAuto:
+                    try fanControl.resetAuto()
                 }
                 NSLog("ThermalForge daemon: re-applied after wake")
             } catch {
@@ -307,73 +352,178 @@ public final class DaemonServer {
 
     private func handleClient(_ fd: Int32) {
         guard isAuthorizedClient(fd) else {
-            NSLog("ThermalForge daemon: rejected unauthorized client")
-            let responseBytes = Array("error: unauthorized client\n".utf8)
-            _ = responseBytes.withUnsafeBufferPointer { buf in
-                write(fd, buf.baseAddress!, buf.count)
-            }
+            TFLogger.shared.event(ThermalEvent(type: .daemonCommandRejected, details: "unauthorized client"))
+            writeResponse(fd, fallbackText: "error: unauthorized client")
             return
         }
 
-        var buffer = [UInt8](repeating: 0, count: 256)
+        var buffer = [UInt8](repeating: 0, count: 65536)
         let n = read(fd, &buffer, buffer.count - 1)
         guard n > 0 else { return }
 
-        let command = String(bytes: buffer[0..<n], encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let bytes = Data(buffer[0..<n])
+        let request = decodeRequest(bytes)
 
-        NSLog("ThermalForge daemon: received: %@", command)
-
-        let response: String
         smcLock.lock()
-        defer { smcLock.unlock() }
-        do {
-            let parts = command.split(separator: " ")
-            switch parts.first.map(String.init) {
-            case "max":
+        let response = handleRequest(request)
+        smcLock.unlock()
+
+        writeResponse(fd, typed: response, fallbackText: response.ok ? "ok" : "error: \(response.error?.message ?? "unknown")")
+    }
+
+    private func decodeRequest(_ data: Data) -> DaemonRequest {
+        if let req = try? DaemonCodec.decodeRequest(data) {
+            return req
+        }
+
+        let plain = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = plain.split(separator: " ")
+        guard let first = parts.first.map(String.init) else {
+            return DaemonRequest(command: "invalid")
+        }
+
+        if first == "set", parts.count >= 2, let rpm = Int(parts[1]) {
+            return DaemonRequest(command: "set", rpm: rpm)
+        }
+        return DaemonRequest(command: first)
+    }
+
+    private func handleRequest(_ request: DaemonRequest) -> DaemonResponse {
+        switch request.command {
+        case "max":
+            return withErrorBoundary(requestID: request.requestID) {
                 try fanControl.setMax()
                 heartbeatLock.lock()
-                lastCommand = "max"
+                lastCommand = .setMax
                 lastHeartbeat = Date()
                 heartbeatLock.unlock()
-                response = "ok"
-            case "auto":
+                return DaemonResponse(requestID: request.requestID, ok: true, message: "ok")
+            }
+
+        case "auto":
+            return withErrorBoundary(requestID: request.requestID) {
                 try fanControl.resetAuto()
                 heartbeatLock.lock()
                 lastCommand = nil
                 lastHeartbeat = nil
                 heartbeatLock.unlock()
-                response = "ok"
-            case "set":
-                guard parts.count >= 2, let rpm = Float(parts[1]) else {
-                    response = "error: usage: set <rpm>"
-                    break
-                }
-                try fanControl.setAllFans(rpm: rpm)
-                heartbeatLock.lock()
-                lastCommand = command
-                lastHeartbeat = Date()
-                heartbeatLock.unlock()
-                response = "ok"
-            case "status":
-                let status = try fanControl.status()
-                let encoder = JSONEncoder()
-                encoder.keyEncodingStrategy = .convertToSnakeCase
-                let data = try encoder.encode(status)
-                response = String(data: data, encoding: .utf8) ?? "error: encode failed"
-            case "heartbeat":
-                heartbeatLock.lock()
-                lastHeartbeat = Date()
-                heartbeatLock.unlock()
-                response = "ok"
-            default:
-                response = "error: unknown command '\(command)'"
+                return DaemonResponse(requestID: request.requestID, ok: true, message: "ok")
             }
+
+        case "set":
+            guard let rpm = request.rpm else {
+                return DaemonResponse(
+                    requestID: request.requestID,
+                    ok: false,
+                    error: DaemonErrorPayload(code: "validation_error", message: "usage: set <rpm>")
+                )
+            }
+            return withErrorBoundary(requestID: request.requestID) {
+                try fanControl.setAllFans(rpm: Float(rpm))
+                heartbeatLock.lock()
+                lastCommand = .setRPM(Float(rpm))
+                lastHeartbeat = Date()
+                heartbeatLock.unlock()
+                return DaemonResponse(requestID: request.requestID, ok: true, message: "ok")
+            }
+
+        case "status":
+            return withErrorBoundary(requestID: request.requestID) {
+                let status = try fanControl.status()
+                return DaemonResponse(requestID: request.requestID, ok: true, status: status)
+            }
+
+        case "heartbeat":
+            heartbeatLock.lock()
+            lastHeartbeat = Date()
+            heartbeatLock.unlock()
+            return DaemonResponse(requestID: request.requestID, ok: true, message: "ok")
+
+        case "rules.list":
+            return DaemonResponse(requestID: request.requestID, ok: true, rules: RulePersistence.load())
+
+        case "rules.put":
+            guard let rule = request.rule else {
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "validation_error", message: "missing rule payload"))
+            }
+            var rules = RulePersistence.load()
+            if let idx = rules.firstIndex(where: { $0.id == rule.id }) {
+                rules[idx] = rule
+            } else {
+                rules.append(rule)
+            }
+            do {
+                try RulePersistence.save(rules)
+                return DaemonResponse(requestID: request.requestID, ok: true, rules: rules)
+            } catch {
+                TFLogger.shared.event(ThermalEvent(type: .daemonCommandFailed, details: "rules.put failed: \(error)"))
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "persist_failed", message: "\(error)"))
+            }
+
+        case "rules.remove":
+            guard let ruleID = request.ruleID else {
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "validation_error", message: "missing ruleID"))
+            }
+            var rules = RulePersistence.load()
+            rules.removeAll(where: { $0.id == ruleID })
+            do {
+                try RulePersistence.save(rules)
+                return DaemonResponse(requestID: request.requestID, ok: true, rules: rules)
+            } catch {
+                TFLogger.shared.event(ThermalEvent(type: .daemonCommandFailed, details: "rules.remove failed: \(error)"))
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "persist_failed", message: "\(error)"))
+            }
+
+        case "rules.enable", "rules.disable":
+            guard let ruleID = request.ruleID else {
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "validation_error", message: "missing ruleID"))
+            }
+            let desired = request.command == "rules.enable"
+            var rules = RulePersistence.load()
+            if let idx = rules.firstIndex(where: { $0.id == ruleID }) {
+                rules[idx].enabled = desired
+            }
+            do {
+                try RulePersistence.save(rules)
+                return DaemonResponse(requestID: request.requestID, ok: true, rules: rules)
+            } catch {
+                TFLogger.shared.event(ThermalEvent(type: .daemonCommandFailed, details: "\(request.command) failed: \(error)"))
+                return DaemonResponse(requestID: request.requestID, ok: false, error: DaemonErrorPayload(code: "persist_failed", message: "\(error)"))
+            }
+
+        default:
+            TFLogger.shared.event(ThermalEvent(type: .daemonCommandRejected, details: "unknown command: \(request.command)"))
+            return DaemonResponse(
+                requestID: request.requestID,
+                ok: false,
+                error: DaemonErrorPayload(code: "unknown_command", message: "unknown command '\(request.command)'")
+            )
+        }
+    }
+
+    private func withErrorBoundary(requestID: String, _ body: () throws -> DaemonResponse) -> DaemonResponse {
+        do {
+            return try body()
         } catch {
-            response = "error: \(error)"
+            TFLogger.shared.event(ThermalEvent(type: .daemonCommandFailed, details: "request failed: \(error)"))
+            return DaemonResponse(
+                requestID: requestID,
+                ok: false,
+                error: DaemonErrorPayload(code: "command_failed", message: "\(error)")
+            )
+        }
+    }
+
+    private func writeResponse(_ fd: Int32, typed: DaemonResponse? = nil, fallbackText: String) {
+        if let typed, let data = try? DaemonCodec.encodeResponse(typed) {
+            let bytes = [UInt8](data)
+            _ = bytes.withUnsafeBufferPointer { buf in
+                write(fd, buf.baseAddress!, buf.count)
+            }
+            return
         }
 
-        let responseBytes = Array((response + "\n").utf8)
+        let responseBytes = Array((fallbackText + "\n").utf8)
         _ = responseBytes.withUnsafeBufferPointer { buf in
             write(fd, buf.baseAddress!, buf.count)
         }
@@ -406,7 +556,7 @@ private func currentConsoleUID() -> uid_t? {
     return st.st_uid
 }
 
-/// Copy a path string into sockaddr_un.sun_path
+/// Copy a path string into sockaddr_un.sun_path.
 private func setPath(_ addr: inout sockaddr_un, _ path: String) {
     withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
         ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -41,11 +41,11 @@ public struct FanInfo {
     public let mode: String
 }
 
-public struct ThermalStatus: Encodable {
+public struct ThermalStatus: Codable, Equatable {
     public let fans: [FanStatus]
     public let temperatures: [String: Float]
 
-    public struct FanStatus: Encodable {
+    public struct FanStatus: Codable, Equatable {
         public let index: Int
         public let actualRPM: Int
         public let targetRPM: Int

--- a/Sources/ThermalForgeCore/Hardware/FanControl+Protocols.swift
+++ b/Sources/ThermalForgeCore/Hardware/FanControl+Protocols.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension FanControl: FanController, SensorProvider {}

--- a/Sources/ThermalForgeCore/Hardware/FanController.swift
+++ b/Sources/ThermalForgeCore/Hardware/FanController.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public protocol FanController {
+    func setMax() throws
+    func setAllFans(rpm: Float) throws
+    func resetAuto() throws
+}
+
+public protocol SensorProvider {
+    func status() throws -> ThermalStatus
+}

--- a/Sources/ThermalForgeCore/Logger.swift
+++ b/Sources/ThermalForgeCore/Logger.swift
@@ -16,6 +16,7 @@ public final class TFLogger {
     private let lock = NSLock()
     private let isoFormatter = ISO8601DateFormatter()
     private let dateFormatter: DateFormatter
+    private let eventEncoder = JSONEncoder()
 
     /// How many days of logs to keep. Default 7.
     public var retentionDays: Int = 7
@@ -26,12 +27,19 @@ public final class TFLogger {
         return logDir.appendingPathComponent("thermalforge-\(dateStr).log")
     }
 
+    /// Current day's machine-readable event log.
+    private var eventLogFile: URL {
+        let dateStr = dateFormatter.string(from: Date())
+        return logDir.appendingPathComponent("thermalforge-events-\(dateStr).jsonl")
+    }
+
     private init() {
         logDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/ThermalForge")
 
         dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
+        eventEncoder.outputFormatting = [.sortedKeys]
 
         try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
 
@@ -67,6 +75,26 @@ public final class TFLogger {
 
     public func info(_ message: String) {
         write("INFO", message)
+    }
+
+    public func event(_ event: ThermalEvent) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let data = try? eventEncoder.encode(event),
+              let line = String(data: data, encoding: .utf8)
+        else { return }
+
+        let entry = line + "\n"
+        if let handle = try? FileHandle(forWritingTo: eventLogFile) {
+            handle.seekToEndOfFile()
+            if let payload = entry.data(using: .utf8) {
+                handle.write(payload)
+            }
+            handle.closeFile()
+        } else {
+            try? entry.write(to: eventLogFile, atomically: true, encoding: .utf8)
+        }
     }
 
     // MARK: - Writing

--- a/Sources/ThermalForgeCore/Observability/EventTypes.swift
+++ b/Sources/ThermalForgeCore/Observability/EventTypes.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum ThermalEventType: String, Codable {
+    case safetyOverrideTriggered
+    case safetyOverrideCleared
+    case ruleTriggered
+    case daemonCommandRejected
+    case daemonCommandFailed
+}
+
+public struct ThermalEvent: Codable {
+    public let timestamp: String
+    public let type: ThermalEventType
+    public let details: String
+
+    public init(type: ThermalEventType, details: String) {
+        self.timestamp = ISO8601DateFormatter().string(from: Date())
+        self.type = type
+        self.details = details
+    }
+}

--- a/Sources/ThermalForgeCore/Profile.swift
+++ b/Sources/ThermalForgeCore/Profile.swift
@@ -223,7 +223,7 @@ extension FanProfile {
                      sustainedTriggerSec: 6)
     )
 
-    public static let builtIn: [FanProfile] = [silent, balanced, performance, max]
+    public static let builtIn: [FanProfile] = [silent, balanced, performance, max, smart]
 }
 
 // MARK: - Persistence

--- a/Sources/ThermalForgeCore/ThermalForgeVersion.swift
+++ b/Sources/ThermalForgeCore/ThermalForgeVersion.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum ThermalForgeVersion {
+    public static let current = "0.2.0"
+}

--- a/Sources/ThermalForgeCore/ThermalLogger.swift
+++ b/Sources/ThermalForgeCore/ThermalLogger.swift
@@ -89,7 +89,7 @@ public final class ThermalLogger {
         self.metadata = LogSessionMetadata(
             machine: machine,
             osVersion: osVersion,
-            thermalForgeVersion: "0.1.0",
+            thermalForgeVersion: ThermalForgeVersion.current,
             fanCount: fanCount,
             maxRPM: Int(fan0?.maxRPM ?? 0),
             minRPM: Int(fan0?.minRPM ?? 0),

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -31,7 +31,8 @@ public enum MonitorState: Equatable {
 // MARK: - Thermal Monitor
 
 public final class ThermalMonitor {
-    private let fanControl: FanControl
+    private let sensorProvider: SensorProvider
+    private let controlService: ControlService
     private var timer: DispatchSourceTimer?
     private let queue = DispatchQueue(label: "com.thermalforge.monitor")
 
@@ -77,10 +78,11 @@ public final class ThermalMonitor {
     private var processBuffer: [(timestamp: String, processes: String)] = []
     private let isoFormatter = ISO8601DateFormatter()
 
-    /// Call this to suppress anomaly logging during calibration
+    /// Call this to suppress anomaly logging during calibration.
     public func setCalibrating(_ value: Bool) {
         queue.async { self.isCalibrating = value }
     }
+
     private var calibration: CalibrationData? = {
         guard let data = CalibrationData.load() else { return nil }
         if let error = data.validationError {
@@ -90,15 +92,34 @@ public final class ThermalMonitor {
         return data
     }()
 
-    /// Called on UI update cadence (every 500ms) with updated status
+    /// Called on UI update cadence (every 500ms) with updated status.
     public var onUpdate: ((ThermalStatus, FanProfile, MonitorState) -> Void)?
-    /// Called when a fan command needs to be executed (may require privilege)
+    /// Called when a fan command needs to be executed (may require privilege).
     public var onFanCommand: ((FanCommand) throws -> Void)?
 
-    public init(fanControl: FanControl, profile: FanProfile = .silent) {
-        self.fanControl = fanControl
+    public init(
+        sensorProvider: SensorProvider,
+        profile: FanProfile = .silent,
+        controlService: ControlService = ControlService()
+    ) {
+        self.sensorProvider = sensorProvider
         self.activeProfile = profile
+        self.controlService = controlService
         self.tickInterval = 0.1
+    }
+
+    public convenience init(
+        fanControl: FanControl,
+        profile: FanProfile = .silent,
+        controlService: ControlService = ControlService()
+    ) {
+        self.init(sensorProvider: fanControl, profile: profile, controlService: controlService)
+    }
+
+    public func updateRules(_ rules: [ThermalRule], enabled: Bool) {
+        queue.async { [self] in
+            controlService.replaceRules(rules, enabled: enabled)
+        }
     }
 
     // MARK: - Lifecycle
@@ -130,7 +151,7 @@ public final class ThermalMonitor {
             tickCounter = 0
 
             if profile.id == "smart" {
-                // Reset Smart state and reload calibration data
+                // Reset Smart state and reload calibration data.
                 tempHistory.removeAll()
                 let loaded = CalibrationData.load()
                 if let error = loaded?.validationError {
@@ -141,14 +162,14 @@ public final class ThermalMonitor {
                 }
             }
 
-            state = .idle
+            state = controlService.transition(.idle)
         }
     }
 
     // MARK: - Polling
 
     private func tick() {
-        guard let status = try? fanControl.status() else { return }
+        guard let status = try? sensorProvider.status() else { return }
         latestStatus = status
 
         // Extract peak temperatures
@@ -163,14 +184,15 @@ public final class ThermalMonitor {
             monitorTick(status: status, maxTemp: maxTemp)
         }
 
-        // Safety override: any sensor > 95°C
+        // Safety override: any sensor > 95°C.
         if maxTemp >= FanProfile.safetyTempThreshold {
             if state != .safetyOverride {
                 applyCommand(.setMax)
-                state = .safetyOverride
+                state = controlService.transition(.safetyTriggered)
                 fansCurrentlyRunning = true
                 lastAppliedRPMPercent = 1.0
                 TFLogger.shared.safety("Override triggered: \(String(format: "%.1f", maxTemp))°C — fans maxed")
+                TFLogger.shared.event(ThermalEvent(type: .safetyOverrideTriggered, details: "maxTemp=\(String(format: "%.1f", maxTemp))"))
             }
             if tickCounter % Self.uiUpdateCadence == 0 {
                 onUpdate?(status, activeProfile, state)
@@ -179,15 +201,15 @@ public final class ThermalMonitor {
             return
         }
 
-        // Clear safety override with hysteresis
+        // Clear safety override with hysteresis.
         if state == .safetyOverride
             && maxTemp < FanProfile.safetyTempThreshold - FanProfile.hysteresisDegrees
         {
-            state = .idle
+            state = controlService.transition(.safetyCleared)
+            TFLogger.shared.event(ThermalEvent(type: .safetyOverrideCleared, details: "maxTemp=\(String(format: "%.1f", maxTemp))"))
         }
 
         // Sustained trigger: track consecutive ticks above start threshold.
-        // Per-profile duration — converted to tick count at runtime.
         let startThreshold = activeProfile.curve.startTemp
         if maxTemp >= startThreshold {
             sustainedAboveCount += 1
@@ -195,14 +217,61 @@ public final class ThermalMonitor {
             sustainedAboveCount = 0
         }
 
-        // Profile-specific logic
+        // Rule engine preemption (after safety, before profile curve).
+        let context = RuleEvaluationContext(
+            cpuTemp: cpuTemp,
+            gpuTemp: gpuTemp,
+            maxTemp: maxTemp,
+            profileID: activeProfile.id
+        )
+        if let decision = controlService.evaluateRules(context: context) {
+            var preempted = false
+
+            if let profileID = decision.profileID,
+               let targetProfile = FanProfile.builtIn.first(where: { $0.id == profileID })
+            {
+                activeProfile = targetProfile
+                preempted = true
+            }
+
+            if let command = decision.command {
+                applyCommand(command)
+                switch command {
+                case .setMax:
+                    lastAppliedRPMPercent = 1.0
+                    fansCurrentlyRunning = true
+                    state = controlService.transition(.profileActive("Rule: \(decision.sourceRuleName)"))
+                case .setRPM(let rpm):
+                    let maxRPM = status.fans.first.map { Float($0.maxRPM) } ?? 7826
+                    lastAppliedRPMPercent = min(max(rpm / maxRPM, 0), 1)
+                    fansCurrentlyRunning = rpm > 0
+                    state = controlService.transition(.profileActive("Rule: \(decision.sourceRuleName)"))
+                case .resetAuto:
+                    lastAppliedRPMPercent = 0
+                    fansCurrentlyRunning = false
+                    state = controlService.transition(.idle)
+                }
+                preempted = true
+            }
+
+            if preempted {
+                TFLogger.shared.event(ThermalEvent(type: .ruleTriggered, details: "rule=\(decision.sourceRuleID) name=\(decision.sourceRuleName)"))
+                if tickCounter % Self.uiUpdateCadence == 0 {
+                    onUpdate?(status, activeProfile, state)
+                }
+                tickCounter += 1
+                return
+            }
+        }
+
+        // Profile-specific logic.
         if activeProfile.id == "smart" {
             tickSmart(status: status, peakTemp: maxTemp)
         } else {
             tickCurve(status: status, peakTemp: maxTemp)
         }
 
-        // UI update at slower cadence (every 500ms)
+        // UI update at slower cadence (every 500ms).
         if tickCounter % Self.uiUpdateCadence == 0 {
             onUpdate?(status, activeProfile, state)
         }
@@ -215,19 +284,15 @@ public final class ThermalMonitor {
     /// Heavy operations: process capture + anomaly detection.
     /// Runs at 2-second intervals to avoid sysctl overhead at 100ms.
     private func monitorTick(status: ThermalStatus, maxTemp: Float) {
-        // Rolling process buffer — always capturing, like a security camera
         let currentProcs = captureTopProcesses()
         let ts = isoFormatter.string(from: Date())
         processBuffer.append((timestamp: ts, processes: currentProcs))
         if processBuffer.count > 15 { processBuffer.removeFirst() }
 
-        // Anomaly detection: two tiers
-        // Tier 1: instant spike — >5°C between consecutive readings (2 seconds)
-        // Tier 2: sustained change — >10°C over 30 seconds
         if !isCalibrating {
             var spikeDetected = false
 
-            // Tier 1: check against previous reading
+            // Tier 1: instant spike — >5°C between consecutive 2-second readings.
             if let prevTemp = anomalyHistory.last {
                 let instantDelta = maxTemp - prevTemp
                 if abs(instantDelta) > 5 {
@@ -235,15 +300,15 @@ public final class ThermalMonitor {
                     let fan0 = status.fans.first
                     TFLogger.shared.info(
                         "Instant \(direction): \(String(format: "%.1f", prevTemp))→\(String(format: "%.1f", maxTemp))°C " +
-                        "(\(String(format: "%+.1f", instantDelta))°C in 2s) | " +
-                        "Fan0: \(fan0?.actualRPM ?? 0) RPM (\(fan0?.mode ?? "?")) | " +
-                        "Profile: \(activeProfile.name)"
+                            "(\(String(format: "%+.1f", instantDelta))°C in 2s) | " +
+                            "Fan0: \(fan0?.actualRPM ?? 0) RPM (\(fan0?.mode ?? "?")) | " +
+                            "Profile: \(activeProfile.name)"
                     )
                     spikeDetected = true
                 }
             }
 
-            // Tier 2: check over 30-second window
+            // Tier 2: sustained change — >10°C over 30 seconds.
             if anomalyHistory.count >= 15 {
                 let oldest = anomalyHistory.first!
                 let sustainedDelta = maxTemp - oldest
@@ -252,16 +317,15 @@ public final class ThermalMonitor {
                     let fan0 = status.fans.first
                     TFLogger.shared.info(
                         "Sustained \(direction): \(String(format: "%.1f", oldest))→\(String(format: "%.1f", maxTemp))°C " +
-                        "(\(String(format: "%+.1f", sustainedDelta))°C in 30s) | " +
-                        "Fan0: \(fan0?.actualRPM ?? 0) RPM (\(fan0?.mode ?? "?")) | " +
-                        "Profile: \(activeProfile.name)"
+                            "(\(String(format: "%+.1f", sustainedDelta))°C in 30s) | " +
+                            "Fan0: \(fan0?.actualRPM ?? 0) RPM (\(fan0?.mode ?? "?")) | " +
+                            "Profile: \(activeProfile.name)"
                     )
                     spikeDetected = true
                     anomalyHistory.removeAll()
                 }
             }
 
-            // Dump the rolling buffer on any spike — shows what was running BEFORE
             if spikeDetected {
                 TFLogger.shared.info("Pre-spike process history (last \(processBuffer.count * 2)s):")
                 for entry in processBuffer {
@@ -276,16 +340,11 @@ public final class ThermalMonitor {
 
     // MARK: - Smart Profile
 
-    /// Target temperature ceiling — keep below this to avoid any throttling
     private static let smartCeiling: Float = 85.0
-    /// Smart starts earlier than other profiles to get ahead of rising temps
     private static let smartFloor: Float = 53.0
-
-    /// All profiles share the same off threshold — 50°C matches Apple's observed stop range
     private static let smartStopTemp: Float = 50.0
 
     private func tickSmart(status: ThermalStatus, peakTemp: Float) {
-        // Sample temperature history at monitor cadence (2s) for stable rate-of-change
         if tickCounter % Self.monitorCadence == 0 {
             tempHistory.append(peakTemp)
             if tempHistory.count > 4 { tempHistory.removeFirst() }
@@ -295,27 +354,23 @@ public final class ThermalMonitor {
         let minRPM = status.fans.first.map { Float($0.minRPM) } ?? 2317
         let minPct = minRPM / maxRPM
 
-        // Below stop threshold and fans running: turn off (with hysteresis)
         if peakTemp < Self.smartStopTemp && fansCurrentlyRunning && rateOfChange() <= 0 {
             applyCommand(.resetAuto)
             lastAppliedRPMPercent = 0
             fansCurrentlyRunning = false
-            state = .idle
+            state = controlService.transition(.idle)
             TFLogger.shared.fan("Smart fans off: \(String(format: "%.1f", peakTemp))°C below \(Int(Self.smartStopTemp))°C")
             return
         }
 
-        // Below floor and fans not running: stay off
         if peakTemp < Self.smartFloor && !fansCurrentlyRunning {
             return
         }
 
-        // In hysteresis band (50-53°C): maintain current state
         if peakTemp >= Self.smartStopTemp && peakTemp < Self.smartFloor && !fansCurrentlyRunning {
             return
         }
 
-        // Sustained trigger: per-profile duration
         let sustainedTicksNeeded = Int(activeProfile.curve.sustainedTriggerSec / tickInterval)
         if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded {
             if sustainedAboveCount == 1 {
@@ -328,20 +383,15 @@ public final class ThermalMonitor {
         var targetPct: Float
 
         if let cal = calibration, let calPct = cal.fanPercentForTemp(peakTemp) {
-            // Calibrated: use machine-specific temp→fan lookup
             targetPct = calPct
-
             if rate > 0 {
-                // Rising: boost proportionally to rate and proximity to ceiling
                 let urgency = min(max((peakTemp - Self.smartFloor) / (Self.smartCeiling - Self.smartFloor), 0), 1)
                 targetPct = min(targetPct + rate * 0.15 * (1 + urgency), 1.0)
             }
         } else {
-            // Uncalibrated: S-curve (matches profile curveShape)
             let range = Self.smartCeiling - Self.smartFloor
             let position = min(max((peakTemp - Self.smartFloor) / range, 0), 1)
             targetPct = position * position * (3 - 2 * position)
-
             if rate > 0 {
                 targetPct = min(targetPct + rate * 0.2, 1.0)
             }
@@ -351,13 +401,11 @@ public final class ThermalMonitor {
             targetPct = 1.0
         }
 
-        // Clamp to valid range, enforce minimum RPM
         targetPct = min(max(targetPct, 0), 1.0)
         if targetPct > 0 && targetPct < minPct {
             targetPct = minPct
         }
 
-        // Ramp governors — per-profile rates, per-tick amounts
         let rampUp = activeProfile.curve.rampUpPerSec * tickInterval
         let rampDown = activeProfile.curve.rampDownPerSec * tickInterval
 
@@ -367,7 +415,6 @@ public final class ThermalMonitor {
             targetPct = max(targetPct, lastAppliedRPMPercent - rampDown)
         }
 
-        // Apply if changed meaningfully (threshold scaled for 100ms ticks)
         if abs(targetPct - lastAppliedRPMPercent) > 0.002 {
             let targetRPM = max(maxRPM * targetPct, minRPM)
             applyCommand(.setRPM(targetRPM))
@@ -378,9 +425,9 @@ public final class ThermalMonitor {
 
             lastAppliedRPMPercent = targetPct
             fansCurrentlyRunning = true
-            state = .active(profileName: "Smart")
+            state = controlService.transition(.profileActive("Smart"))
         } else if fansCurrentlyRunning {
-            state = .active(profileName: "Smart")
+            state = controlService.transition(.profileActive("Smart"))
         }
     }
 
@@ -390,7 +437,6 @@ public final class ThermalMonitor {
         guard tempHistory.count >= 2 else { return 0 }
         let oldest = tempHistory.first!
         let newest = tempHistory.last!
-        // tempHistory sampled at monitor cadence (2s intervals)
         let seconds = Float(tempHistory.count - 1) * Float(Self.monitorCadence) * tickInterval
         return (newest - oldest) / seconds
     }
@@ -402,32 +448,27 @@ public final class ThermalMonitor {
         let maxRPM = status.fans.first.map { Float($0.maxRPM) } ?? 7826
         let minRPM = status.fans.first.map { Float($0.minRPM) } ?? 2317
 
-        // Hands-off profiles (Silent): don't control fans, just monitor
         if curve.handsOff {
             if fansCurrentlyRunning {
                 applyCommand(.resetAuto)
                 fansCurrentlyRunning = false
                 lastAppliedRPMPercent = 0
-                state = .idle
+                state = controlService.transition(.idle)
             }
             return
         }
 
-        // Get target from curve (now applies curve shape: easeIn, linear, easeOut, sCurve)
         guard let rawTarget = curve.targetPercent(at: peakTemp, fansCurrentlyRunning: fansCurrentlyRunning) else {
-            // Curve says fans should be off
             if fansCurrentlyRunning {
                 applyCommand(.resetAuto)
                 fansCurrentlyRunning = false
                 lastAppliedRPMPercent = 0
-                state = .idle
+                state = controlService.transition(.idle)
                 TFLogger.shared.fan("Fans off: \(String(format: "%.1f", peakTemp))°C below \(Int(curve.stopTemp))°C [\(activeProfile.name)]")
             }
             return
         }
 
-        // Sustained trigger: per-profile duration.
-        // Converted to tick count at runtime based on tick interval.
         let sustainedTicksNeeded = Int(curve.sustainedTriggerSec / tickInterval)
         if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded {
             if sustainedAboveCount == 1 {
@@ -436,28 +477,20 @@ public final class ThermalMonitor {
             return
         }
 
-        // 0.001 signals "keep at minimum" (hysteresis band)
         var targetPct = rawTarget <= 0.001 ? minRPM / maxRPM : rawTarget
-
-        // Clamp to valid range
         targetPct = min(max(targetPct, minRPM / maxRPM), curve.maxRPMPercent)
 
-        // Ramp governors — per-profile rates, per-tick amounts
         let rampUp = curve.rampUpPerSec * tickInterval
         let rampDown = curve.rampDownPerSec * tickInterval
 
         if targetPct > lastAppliedRPMPercent {
             if !curve.instantEngage {
-                // Governed ramp-up
                 targetPct = min(targetPct, lastAppliedRPMPercent + rampUp)
             }
-            // instantEngage: skip governor, jump directly to target
         } else if targetPct < lastAppliedRPMPercent {
-            // Ramp-down governor always applies (even for instantEngage profiles)
             targetPct = max(targetPct, lastAppliedRPMPercent - rampDown)
         }
 
-        // Apply if changed meaningfully (threshold scaled for 100ms ticks)
         if abs(targetPct - lastAppliedRPMPercent) > 0.002 {
             let targetRPM = max(maxRPM * targetPct, minRPM)
             applyCommand(.setRPM(targetRPM))
@@ -468,15 +501,15 @@ public final class ThermalMonitor {
 
             lastAppliedRPMPercent = targetPct
             fansCurrentlyRunning = true
-            state = .active(profileName: activeProfile.name)
+            state = controlService.transition(.profileActive(activeProfile.name))
         } else if fansCurrentlyRunning {
-            state = .active(profileName: activeProfile.name)
+            state = controlService.transition(.profileActive(activeProfile.name))
         }
     }
 
     // MARK: - Process Capture
 
-    /// Capture top 5 processes by CPU for anomaly logging
+    /// Capture top 5 processes by CPU for anomaly logging.
     private func captureTopProcesses() -> String {
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
         var size = 0
@@ -527,5 +560,4 @@ public final class ThermalMonitor {
             TFLogger.shared.error("Fan command failed: \(command) — \(error)")
         }
     }
-
 }

--- a/Sources/ThermalForgeCore/Transport/DaemonCodec.swift
+++ b/Sources/ThermalForgeCore/Transport/DaemonCodec.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum DaemonCodec {
+    public static func encodeRequest(_ request: DaemonRequest) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(request)
+    }
+
+    public static func decodeRequest(_ data: Data) throws -> DaemonRequest {
+        try JSONDecoder().decode(DaemonRequest.self, from: data)
+    }
+
+    public static func encodeResponse(_ response: DaemonResponse) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(response)
+    }
+
+    public static func decodeResponse(_ data: Data) throws -> DaemonResponse {
+        try JSONDecoder().decode(DaemonResponse.self, from: data)
+    }
+}

--- a/Sources/ThermalForgeCore/Transport/DaemonProtocol.swift
+++ b/Sources/ThermalForgeCore/Transport/DaemonProtocol.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct DaemonRequest: Codable, Equatable {
+    public var version: Int
+    public var requestID: String
+    public var command: String
+    public var rpm: Int?
+    public var rule: ThermalRule?
+    public var ruleID: String?
+
+    public init(
+        version: Int = 1,
+        requestID: String = UUID().uuidString,
+        command: String,
+        rpm: Int? = nil,
+        rule: ThermalRule? = nil,
+        ruleID: String? = nil
+    ) {
+        self.version = version
+        self.requestID = requestID
+        self.command = command
+        self.rpm = rpm
+        self.rule = rule
+        self.ruleID = ruleID
+    }
+}
+
+public struct DaemonErrorPayload: Codable, Equatable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+public struct DaemonResponse: Codable, Equatable {
+    public var version: Int
+    public var requestID: String
+    public var ok: Bool
+    public var message: String?
+    public var status: ThermalStatus?
+    public var rules: [ThermalRule]?
+    public var error: DaemonErrorPayload?
+
+    public init(
+        version: Int = 1,
+        requestID: String,
+        ok: Bool,
+        message: String? = nil,
+        status: ThermalStatus? = nil,
+        rules: [ThermalRule]? = nil,
+        error: DaemonErrorPayload? = nil
+    ) {
+        self.version = version
+        self.requestID = requestID
+        self.ok = ok
+        self.message = message
+        self.status = status
+        self.rules = rules
+        self.error = error
+    }
+}

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -14,7 +14,7 @@ struct ThermalForge: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "thermalforge",
         abstract: "Fan control for Apple Silicon MacBooks",
-        version: "0.1.0",
+        version: ThermalForgeVersion.current,
         subcommands: [
             Max.self,
             Auto.self,
@@ -24,6 +24,7 @@ struct ThermalForge: ParsableCommand {
             Watch.self,
             Calibrate.self,
             Log.self,
+            Rules.self,
             Install.self,
             Uninstall.self,
             Daemon.self,
@@ -205,7 +206,7 @@ struct Watch: ParsableCommand {
         abstract: "Monitor temps and auto-adjust fans based on a profile"
     )
 
-    @Option(name: .shortAndLong, help: "Profile: silent, balanced, performance, max")
+    @Option(name: .shortAndLong, help: "Profile: silent, balanced, performance, max, smart")
     var profile: String = "balanced"
 
     @Option(name: .shortAndLong, help: "Poll interval in seconds (default 0.1 = 100ms)")
@@ -468,6 +469,178 @@ struct Log: ParsableCommand {
         if t >= 3600 { return "\(Int(t / 3600))h" }
         if t >= 60 { return "\(Int(t / 60))m" }
         return "\(Int(t))s"
+    }
+}
+
+// MARK: - Rules
+
+struct Rules: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "rules",
+        abstract: "Manage IF/THEN/ELSE thermal rules",
+        subcommands: [
+            RulesList.self,
+            RulesAdd.self,
+            RulesRemove.self,
+            RulesEnable.self,
+            RulesDisable.self,
+            RulesTest.self,
+        ]
+    )
+}
+
+struct RulesList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List all persisted rules"
+    )
+
+    func run() throws {
+        let rules = RulePersistence.load().sorted { lhs, rhs in
+            if lhs.priority == rhs.priority { return lhs.name < rhs.name }
+            return lhs.priority > rhs.priority
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(rules)
+        print(String(data: data, encoding: .utf8) ?? "[]")
+    }
+}
+
+struct RulesAdd: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "Add a rule (example: IF temp >= 55 THEN max until <= 65)"
+    )
+
+    @Option(name: .shortAndLong, help: "Rule name")
+    var name: String = "IF temp >= 55 THEN max until <= 65"
+
+    @Option(name: .shortAndLong, help: "Trigger threshold in Celsius")
+    var trigger: Float = 55
+
+    @Option(name: .long, help: "Latch release threshold in Celsius")
+    var until: Float = 65
+
+    @Option(name: .shortAndLong, help: "Priority (higher wins)")
+    var priority: Int = 900
+
+    @Flag(name: .long, help: "Use max fan action")
+    var max: Bool = true
+
+    @Option(name: .long, help: "Set explicit RPM instead of max (when --max is false)")
+    var rpm: Int = 0
+
+    func run() throws {
+        let action: ThermalRuleAction = max ? .setMax : .setRPM(rpm)
+        let rule = ThermalRule(
+            name: name,
+            enabled: true,
+            priority: priority,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: trigger),
+            action: action,
+            untilTempBelowC: until
+        )
+
+        var rules = RulePersistence.load()
+        rules.append(rule)
+        try RulePersistence.save(rules)
+
+        print("Added rule: \(rule.id)")
+    }
+}
+
+struct RulesRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remove",
+        abstract: "Remove a rule by ID"
+    )
+
+    @Argument(help: "Rule ID")
+    var id: String
+
+    func run() throws {
+        var rules = RulePersistence.load()
+        let before = rules.count
+        rules.removeAll(where: { $0.id == id })
+        try RulePersistence.save(rules)
+        let removed = before - rules.count
+        print(removed > 0 ? "Removed \(removed) rule(s)." : "No matching rule.")
+    }
+}
+
+struct RulesEnable: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "enable",
+        abstract: "Enable a rule by ID"
+    )
+
+    @Argument(help: "Rule ID")
+    var id: String
+
+    func run() throws {
+        var rules = RulePersistence.load()
+        guard let idx = rules.firstIndex(where: { $0.id == id }) else {
+            throw ValidationError("Rule not found: \(id)")
+        }
+        rules[idx].enabled = true
+        try RulePersistence.save(rules)
+        print("Enabled rule: \(id)")
+    }
+}
+
+struct RulesDisable: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "disable",
+        abstract: "Disable a rule by ID"
+    )
+
+    @Argument(help: "Rule ID")
+    var id: String
+
+    func run() throws {
+        var rules = RulePersistence.load()
+        guard let idx = rules.firstIndex(where: { $0.id == id }) else {
+            throw ValidationError("Rule not found: \(id)")
+        }
+        rules[idx].enabled = false
+        try RulePersistence.save(rules)
+        print("Disabled rule: \(id)")
+    }
+}
+
+struct RulesTest: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "test",
+        abstract: "Evaluate rules against synthetic temperatures"
+    )
+
+    @Option(name: .long, help: "CPU temperature in Celsius")
+    var cpu: Float = 60
+
+    @Option(name: .long, help: "GPU temperature in Celsius")
+    var gpu: Float = 58
+
+    @Option(name: .long, help: "Profile ID")
+    var profile: String = "balanced"
+
+    func run() throws {
+        let rules = RulePersistence.load()
+        let engine = RuleEngine(rules: rules, isEnabled: true)
+        let maxTemp = max(cpu, gpu)
+        let context = RuleEvaluationContext(cpuTemp: cpu, gpuTemp: gpu, maxTemp: maxTemp, profileID: profile)
+        if let decision = engine.evaluate(context: context) {
+            print("Matched rule: \(decision.sourceRuleName) [\(decision.sourceRuleID)]")
+            if let command = decision.command {
+                print("Command: \(command)")
+            }
+            if let profileID = decision.profileID {
+                print("Profile: \(profileID)")
+            }
+        } else {
+            print("No rule matched.")
+        }
     }
 }
 

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -521,15 +521,14 @@ struct Install: ParsableCommand {
             toFile: ThermalForgeDaemon.plistPath,
             atomically: true, encoding: .utf8
         )
-        // Stop old daemon if one is running
-        if ThermalForgeDaemon.isRunning {
-            let unload = Process()
-            unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
-            try unload.run()
-            unload.waitUntilExit()
-            Thread.sleep(forTimeInterval: 0.5)
-        }
+        // Always try to stop old daemon first.
+        // Do not gate on socket health checks because socket paths can change between versions.
+        let unload = Process()
+        unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
+        try? unload.run()
+        unload.waitUntilExit()
+        Thread.sleep(forTimeInterval: 0.5)
 
         // Start new daemon
         let load = Process()

--- a/Tests/ThermalForgeTests/ControlStateMachineTests.swift
+++ b/Tests/ThermalForgeTests/ControlStateMachineTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import ThermalForgeCore
+
+@Suite("Control State Machine")
+struct ControlStateMachineTests {
+    @Test("Transitions to safety and clears")
+    func safetyTransitions() {
+        var machine = ControlStateMachine()
+        #expect(machine.state == .idle)
+
+        _ = machine.transition(.profileActive("Balanced"))
+        #expect(machine.state == .active(profileName: "Balanced"))
+
+        _ = machine.transition(.safetyTriggered)
+        #expect(machine.state == .safetyOverride)
+
+        _ = machine.transition(.safetyCleared)
+        #expect(machine.state == .idle)
+    }
+
+    @Test("Idle event always resets state")
+    func idleReset() {
+        var machine = ControlStateMachine(initialState: .active(profileName: "Performance"))
+        _ = machine.transition(.idle)
+        #expect(machine.state == .idle)
+    }
+}

--- a/Tests/ThermalForgeTests/DaemonCodecTests.swift
+++ b/Tests/ThermalForgeTests/DaemonCodecTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import ThermalForgeCore
+
+@Suite("Daemon Codec")
+struct DaemonCodecTests {
+    @Test("Request round-trip")
+    func requestRoundTrip() throws {
+        let rule = ThermalRule(
+            id: "rule-1",
+            name: "example",
+            enabled: true,
+            priority: 900,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 55),
+            action: .setMax,
+            untilTempBelowC: 65
+        )
+        let original = DaemonRequest(command: "rules.put", rpm: nil, rule: rule, ruleID: nil)
+        let encoded = try DaemonCodec.encodeRequest(original)
+        let decoded = try DaemonCodec.decodeRequest(encoded)
+        #expect(decoded == original)
+    }
+
+    @Test("Response round-trip with error")
+    func responseRoundTrip() throws {
+        let original = DaemonResponse(
+            requestID: "abc",
+            ok: false,
+            message: nil,
+            status: nil,
+            rules: nil,
+            error: DaemonErrorPayload(code: "validation_error", message: "missing rule")
+        )
+        let encoded = try DaemonCodec.encodeResponse(original)
+        let decoded = try DaemonCodec.decodeResponse(encoded)
+        #expect(decoded == original)
+    }
+}

--- a/Tests/ThermalForgeTests/ProfileTests.swift
+++ b/Tests/ThermalForgeTests/ProfileTests.swift
@@ -57,14 +57,15 @@ struct ProfileTests {
         #expect(FanProfile.smart.curve.sustainedTriggerSec == 6)
     }
 
-    @Test("Four built-in profiles exist")
+    @Test("Five built-in profiles exist")
     func builtInCount() {
-        #expect(FanProfile.builtIn.count == 4)
+        #expect(FanProfile.builtIn.count == 5)
         let ids = FanProfile.builtIn.map(\.id)
         #expect(ids.contains("silent"))
         #expect(ids.contains("balanced"))
         #expect(ids.contains("performance"))
         #expect(ids.contains("max"))
+        #expect(ids.contains("smart"))
     }
 
     @Test("Profile round-trips through JSON")
@@ -74,7 +75,6 @@ struct ProfileTests {
             let decoded = try JSONDecoder().decode(FanProfile.self, from: data)
             #expect(decoded == profile, "Round-trip failed for \(profile.name)")
         }
-        // Also test Smart (not in builtIn but important)
         let smartData = try JSONEncoder().encode(FanProfile.smart)
         let smartDecoded = try JSONDecoder().decode(FanProfile.self, from: smartData)
         #expect(smartDecoded == FanProfile.smart)

--- a/Tests/ThermalForgeTests/RuleEngineTests.swift
+++ b/Tests/ThermalForgeTests/RuleEngineTests.swift
@@ -1,0 +1,73 @@
+import Testing
+
+@testable import ThermalForgeCore
+
+@Suite("Rule Engine")
+struct RuleEngineTests {
+    @Test("Highest priority matching rule wins")
+    func highestPriorityWins() {
+        let low = ThermalRule(
+            id: "low",
+            name: "low",
+            enabled: true,
+            priority: 10,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 55),
+            action: .setRPM(3000)
+        )
+        let high = ThermalRule(
+            id: "high",
+            name: "high",
+            enabled: true,
+            priority: 100,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 55),
+            action: .setMax
+        )
+
+        let engine = RuleEngine(rules: [low, high], isEnabled: true)
+        let decision = engine.evaluate(context: RuleEvaluationContext(cpuTemp: 56, gpuTemp: 52, maxTemp: 56, profileID: "balanced"))
+
+        #expect(decision != nil)
+        #expect(decision?.sourceRuleID == "high")
+        #expect(decision?.command == .setMax)
+    }
+
+    @Test("Latched rule stays active until release threshold")
+    func latchedRule() {
+        let rule = ThermalRule(
+            id: "latched",
+            name: "latched",
+            enabled: true,
+            priority: 500,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 70),
+            action: .setMax,
+            untilTempBelowC: 65
+        )
+
+        let engine = RuleEngine(rules: [rule], isEnabled: true)
+
+        let hot = engine.evaluate(context: RuleEvaluationContext(cpuTemp: 72, gpuTemp: 70, maxTemp: 72, profileID: "balanced"))
+        #expect(hot?.command == .setMax)
+
+        let coolingButStillLatched = engine.evaluate(context: RuleEvaluationContext(cpuTemp: 67, gpuTemp: 64, maxTemp: 67, profileID: "balanced"))
+        #expect(coolingButStillLatched?.command == .setMax)
+
+        let released = engine.evaluate(context: RuleEvaluationContext(cpuTemp: 64, gpuTemp: 63, maxTemp: 64, profileID: "balanced"))
+        #expect(released == nil)
+    }
+
+    @Test("Disabled engine returns no decisions")
+    func disabledEngine() {
+        let rule = ThermalRule(
+            id: "disabled",
+            name: "disabled",
+            enabled: true,
+            priority: 100,
+            condition: ThermalRuleCondition(metric: .maxTemp, comparator: .greaterThanOrEqual, valueCelsius: 55),
+            action: .setMax
+        )
+
+        let engine = RuleEngine(rules: [rule], isEnabled: false)
+        let decision = engine.evaluate(context: RuleEvaluationContext(cpuTemp: 80, gpuTemp: 75, maxTemp: 80, profileID: "max"))
+        #expect(decision == nil)
+    }
+}

--- a/docs/architecture-v2.md
+++ b/docs/architecture-v2.md
@@ -1,0 +1,36 @@
+# Architecture v2
+
+## Layers
+
+1. Hardware
+- `FanControl` for SMC reads/writes
+- `FanController` / `SensorProvider` protocols for testability
+
+2. Control
+- `ThermalMonitor` runtime loop (100ms control cadence)
+- `ControlService` and `ControlStateMachine`
+- `RuleEngine` and persistent rules
+
+3. Transport
+- `DaemonRequest` / `DaemonResponse` typed protocol
+- `DaemonCodec` JSON serialization
+- backward-compatible legacy text command fallback
+
+4. Observability
+- `TFLogger` rotating text logs
+- `ThermalEvent` JSONL event stream
+- `ThermalLogger` research session export
+
+## Runtime Flow
+
+- App/CLI issues command -> daemon socket
+- Daemon authorizes peer UID -> executes command
+- App monitor polls sensors -> applies safety/profile/rules
+- Rule evaluation happens after safety override check and before profile curve logic
+
+## Safety Ordering
+
+1. Hard safety override (95°C)
+2. Rule engine decisions
+3. Profile curve logic
+4. Idle/hysteresis behavior

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -1,0 +1,28 @@
+# Migration to v2
+
+## What Changed
+
+- Smart profile is part of the built-in profile list.
+- Daemon protocol now supports typed JSON request/response.
+- Rule engine is first-class and persisted.
+- Build/install pipeline uses dedicated app bundle script.
+- Version value is sourced from `ThermalForgeVersion.current`.
+
+## User Impact
+
+- Existing profile behavior remains available.
+- Existing shell command usage (`max`, `auto`, `set`, `status`) still works.
+- New rule commands are available under `thermalforge rules ...`.
+
+## Operator Checklist
+
+1. Rebuild and reinstall:
+   - `swift build -c release`
+   - `sudo .build/release/thermalforge install`
+2. Rebuild app bundle:
+   - `sudo ./Scripts/build-app-bundle.sh /Applications/ThermalForge.app`
+3. Restart daemon:
+   - `sudo launchctl kickstart -k system/com.thermalforge.daemon`
+4. Validate:
+   - `thermalforge status`
+   - `thermalforge rules list`

--- a/docs/rule-engine.md
+++ b/docs/rule-engine.md
@@ -1,0 +1,34 @@
+# Rule Engine
+
+## Model
+
+A rule has:
+- `condition` (`metric`, comparator, threshold)
+- `action` (`setMax`, `setRPM`, `resetAuto`, `selectProfile`)
+- `priority` (higher wins)
+- `enabled`
+- optional latch release (`untilTempBelowC`)
+
+## Evaluation
+
+1. Disabled engine -> no rule applies.
+2. Active latched rule executes until release threshold clears.
+3. Otherwise, rules are sorted by priority and first matching enabled rule wins.
+
+## Example
+
+- Condition: `maxTemp >= 55`
+- Action: `setMax`
+- Latch: until `maxTemp <= 65`
+
+CLI:
+
+```bash
+thermalforge rules add --trigger 55 --until 65 --max
+```
+
+## Storage
+
+Rules are persisted at:
+
+`~/Library/Application Support/ThermalForge/rules.json`

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@
 set -e
 
 cd "$(dirname "$0")"
+source ./Scripts/version.sh
 
 echo "Building ThermalForge..."
 swift build -c release --quiet
@@ -29,44 +30,8 @@ fi
 sudo xattr -cr .build/release/thermalforge
 sudo .build/release/thermalforge install
 
-# Create .app bundle in /Applications so it shows in Spotlight/Finder
-APP_DIR="/Applications/ThermalForge.app/Contents"
-sudo mkdir -p "$APP_DIR/MacOS" "$APP_DIR/Resources"
-sudo cp .build/release/ThermalForgeApp "$APP_DIR/MacOS/ThermalForgeApp"
-sudo cp ThermalForge.icns "$APP_DIR/Resources/AppIcon.icns"
-sudo xattr -cr /Applications/ThermalForge.app
-
-sudo tee "$APP_DIR/Info.plist" > /dev/null << 'PLIST'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleName</key>
-    <string>ThermalForge</string>
-    <key>CFBundleDisplayName</key>
-    <string>ThermalForge</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.thermalforge.app</string>
-    <key>CFBundleVersion</key>
-    <string>0.1.0</string>
-    <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
-    <key>CFBundleExecutable</key>
-    <string>ThermalForgeApp</string>
-    <key>CFBundleIconFile</key>
-    <string>AppIcon</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
-    <key>LSUIElement</key>
-    <true/>
-    <key>NSHighResolutionCapable</key>
-    <true/>
-</dict>
-</plist>
-PLIST
+# Create signed app bundle in /Applications so it shows in Spotlight/Finder
+sudo ./Scripts/build-app-bundle.sh /Applications/ThermalForge.app
 
 # Update Spotlight index
 sudo mdimport /Applications/ThermalForge.app 2>/dev/null || true


### PR DESCRIPTION
## Summary
This PR hardens the privileged daemon command path and makes daemon updates more reliable.

## Changes
- Move daemon socket from `/tmp/thermalforge.sock` to `/var/run/thermalforge.sock`.
- Restrict socket permissions to `0600` instead of world-writable access.
- Verify connecting client identity with `getpeereid`; only `root` and the active console user are accepted.
- Return an explicit `error: unauthorized client` response for rejected clients.
- In `install`, always attempt `launchctl bootout` before `bootstrap` to avoid label-collision failures during upgrades.

## Why
Before this change, local untrusted processes could connect to a privileged daemon via a permissive socket path/mode. This update narrows command access to the expected local principals.

Also, update/reinstall could fail with launchd bootstrap errors when an old daemon label was still loaded; unconditional bootout avoids that failure mode.

## Validation
- `swift test` passes.
- Manual daemon restart/install path verified locally.

## Scope
This PR intentionally excludes UI/feature changes and focuses only on daemon security + install robustness.
