### PR TITLE
Fix fan detection on M5 Max (Mac17,6)

### DIFF
--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -98,10 +98,22 @@ public final class FanControl {
 
     public func fanCount() throws -> Int {
         let result = smc.readKey(SMCFanKey.count)
-        guard result.success, !result.bytes.isEmpty else {
+        if result.success, !result.bytes.isEmpty {
+            return Int(result.bytes[0])
+        }
+
+        // FNum is absent on some Apple Silicon SKUs (e.g. M5 Max Mac17,6).
+        // Fall back to probing F<i>Ac until a key is missing.
+        var count = 0
+        for i in 0..<10 {
+            let key = SMCFanKey.key(SMCFanKey.actual, fan: i)
+            guard smc.readKey(key).success else { break }
+            count += 1
+        }
+        guard count > 0 else {
             throw ThermalForgeError.readFailed(SMCFanKey.count)
         }
-        return Int(result.bytes[0])
+        return count
     }
 
     // MARK: - Read Fan Info


### PR DESCRIPTION
FNum is absent on some Apple Silicon SKUs (verified on MacBook Pro M5 Max Mac17,6). fanCount() previously threw readFailed("FNum"), which broke status, set, max, auto, and the menu bar app's monitor tick (which calls status() and silently swallows errors).

Fall back to probing F<i>Ac (0..<10) when FNum is missing, returning the count of present actual-RPM keys. Existing FNum-supporting hardware is unaffected.