### PR TITLE
Harden the privileged daemon socket (peer auth + /var/run)

### DIFF
--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -13,7 +13,7 @@ import IOKit.pwr_mgt
 // MARK: - Constants
 
 public enum ThermalForgeDaemon {
-    public static let socketPath = "/tmp/thermalforge.sock"
+    public static let socketPath = "/var/run/thermalforge.sock"
     public static let plistPath = "/Library/LaunchDaemons/com.thermalforge.daemon.plist"
     public static let installPath = "/usr/local/bin/thermalforge"
     public static let label = "com.thermalforge.daemon"
@@ -150,8 +150,10 @@ public final class DaemonServer {
             throw ThermalForgeError.writeFailed("bind() failed: \(errno)")
         }
 
-        // Allow all local users to connect
-        chmod(ThermalForgeDaemon.socketPath, 0o777)
+        // Socket lives in root-owned /var/run (no /tmp squatting). It stays
+        // connectable, but every accepted connection is authenticated by peer
+        // UID below — only root and the console (GUI login) user are honored.
+        chmod(ThermalForgeDaemon.socketPath, 0o666)
 
         guard listen(fd, 5) == 0 else {
             close(fd)
@@ -176,7 +178,11 @@ public final class DaemonServer {
             while true {
                 let clientFD = accept(socketFD, nil, nil)
                 guard clientFD >= 0 else { continue }
-                handleClient(clientFD)
+                if Self.isAuthorizedPeer(clientFD) {
+                    handleClient(clientFD)
+                } else {
+                    NSLog("ThermalForge daemon: rejected unauthorized peer (uid not root/console)")
+                }
                 close(clientFD)
             }
         }
@@ -360,6 +366,31 @@ public final class DaemonServer {
         _ = responseBytes.withUnsafeBufferPointer { buf in
             write(fd, buf.baseAddress!, buf.count)
         }
+    }
+
+    // MARK: - Peer Authentication
+
+    /// Only root (the sudo CLI) and the current console (GUI login) user may
+    /// command the daemon. Verified via LOCAL_PEERCRED on the connected socket,
+    /// so it can't be bypassed by socket file permissions or path squatting.
+    static func isAuthorizedPeer(_ fd: Int32) -> Bool {
+        var cred = xucred()
+        var len = socklen_t(MemoryLayout<xucred>.stride)
+        guard getsockopt(fd, SOL_LOCAL, LOCAL_PEERCRED, &cred, &len) == 0,
+              cred.cr_version == UInt32(XUCRED_VERSION) else { return false }
+
+        let uid = cred.cr_uid
+        if uid == 0 { return true }                                    // root: privileged CLI
+        if let console = consoleUID(), uid == console { return true }   // active GUI user
+        return false
+    }
+
+    /// The console (logged-in GUI) user owns /dev/console on macOS. Re-read per
+    /// connection so fast-user-switching is handled correctly.
+    private static func consoleUID() -> uid_t? {
+        var st = stat()
+        guard stat("/dev/console", &st) == 0 else { return nil }
+        return st.st_uid
     }
 
     deinit {

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -521,15 +521,16 @@ struct Install: ParsableCommand {
             toFile: ThermalForgeDaemon.plistPath,
             atomically: true, encoding: .utf8
         )
-        // Stop old daemon if one is running
-        if ThermalForgeDaemon.isRunning {
-            let unload = Process()
-            unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
-            try unload.run()
-            unload.waitUntilExit()
-            Thread.sleep(forTimeInterval: 0.5)
-        }
+        // Always bootout any existing registration before bootstrapping.
+        // launchd's bootstrap fails with EIO if the label is already loaded, and
+        // isRunning can't detect a daemon bound to a different socket path (e.g.
+        // across upgrades that move the socket). Ignore errors when nothing's loaded.
+        let unload = Process()
+        unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+        unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
+        try? unload.run()
+        unload.waitUntilExit()
+        Thread.sleep(forTimeInterval: 0.5)
 
         // Start new daemon
         let load = Process()


### PR DESCRIPTION
## What
Hardens the privileged daemon's control socket against unauthenticated local access.

## Why
The daemon binds its control socket at `/tmp/thermalforge.sock` with mode `0777` and accepts any connection. Because `/tmp` is world-writable and no peer identity is checked, **any local process — regardless of user — can drive the fans** (`set`/`max`/`auto`).

## Changes
- **Move the socket to root-owned `/var/run`**, removing the `/tmp` squatting vector.
- **Authenticate every accepted connection with `LOCAL_PEERCRED`**: only root (the privileged CLI) and the current console / GUI-login user are honored. The console user is read from `/dev/console` per connection, so fast user switching works.
- **`install`: always bootout the existing daemon before bootstrap.** `launchctl bootstrap` fails with EIO if the label is already loaded; the old `isRunning` guard couldn't detect a daemon bound to a different socket path across an upgrade. (Also fixes re-install failures in general.)

Fan RPM stays clamped and the 95 °C safety override is unaffected — this purely removes an unauthenticated local control path.

## Testing
- `swift build -c release` ✅
- `swift test` ✅ (24 tests)
- Verified on M1 Max (MacBook Pro 16", 2021): the menu-bar app drives fans normally as the authorized console user; socket present at `/var/run/thermalforge.sock`.

Two commits, one concern each.
