### PR TITLE
Lower idle CPU by polling at 250ms

### DIFF
--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -42,15 +42,17 @@ public final class ThermalMonitor {
     // MARK: - Tick Timing
 
     /// Thermal tick interval in seconds. Fan control runs at this rate.
-    private let tickInterval: Float
+    /// 250ms keeps the app's idle CPU low while staying responsive — fans ramp
+    /// over seconds, so sub-250ms polling buys nothing but CPU burn.
+    private var tickInterval: Float
 
     /// Monitor cadence: process capture + anomaly detection every N thermal ticks.
-    /// At 100ms thermal tick, 20 × 0.1s = 2 seconds.
-    private static let monitorCadence = 20
+    /// At 250ms thermal tick, 8 × 0.25s = 2 seconds.
+    private static let monitorCadence = 8
 
     /// UI update cadence: onUpdate fires every N thermal ticks.
-    /// At 100ms thermal tick, 5 × 0.1s = 500ms — smooth UI without excessive redraws.
-    private static let uiUpdateCadence = 5
+    /// At 250ms thermal tick, 2 × 0.25s = 500ms — smooth UI without excessive redraws.
+    private static let uiUpdateCadence = 2
 
     private var tickCounter = 0
 
@@ -98,13 +100,16 @@ public final class ThermalMonitor {
     public init(fanControl: FanControl, profile: FanProfile = .silent) {
         self.fanControl = fanControl
         self.activeProfile = profile
-        self.tickInterval = 0.1
+        self.tickInterval = 0.25
     }
 
     // MARK: - Lifecycle
 
-    public func start(interval: TimeInterval = 0.1) {
+    public func start(interval: TimeInterval = 0.25) {
         stop()
+
+        // Keep the ramp/sustained math in sync with the actual timer rate.
+        tickInterval = Float(interval)
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now(), repeating: interval)


### PR DESCRIPTION
## What
Drops the thermal poll rate from 100 ms (10 Hz) to 250 ms (4 Hz).

## Why
At 100 ms the menu-bar app sits around ~11 % CPU at idle — a lot for a tool whose job is to keep the machine cool and quiet. Fans ramp over seconds, so sub-250 ms polling buys no real responsiveness, only wakeups.

## Changes
- Thermal tick 100 ms → 250 ms.
- Rescale the derived cadences so **wall-clock behavior is unchanged**: monitor cadence 20 → 8 (still 2 s), UI cadence 5 → 2 (still 500 ms).
- Make `tickInterval` track the actual timer rate in `start(interval:)`, fixing a latent desync where the ramp / sustained-trigger math assumed 100 ms even when `start` was called with a different interval (e.g. the CLI `watch --interval` path).

## Measured impact (M1 Max, MacBook Pro 16" 2021)
Idle `ThermalForgeApp` CPU dropped from **~11 % to ~8.4 %** (interval-sampled with `top -l`), roughly a **24 % reduction**. Fan behavior is unchanged.

The saving is bounded because the UI refresh (500 ms) and process capture (2 s) cadences are deliberately preserved — only the bare thermal tick goes from 10 Hz to 4 Hz. The remaining idle cost is dominated by `status()` re-probing the full SMC temperature-key set every tick (including keys absent on the given hardware); caching the live key set would cut more, but that's a separate change.

## Testing
- `swift build -c release` ✅
- `swift test` ✅ (24 tests)
