### PR TITLE
Add an Extra Cool profile modifier

### DIFF
--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -18,6 +18,14 @@ final class AppState: ObservableObject {
     @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
         didSet { UserDefaults.standard.set(useFahrenheit, forKey: "useFahrenheit") }
     }
+    /// Extra Cool: shift every active profile colder-but-louder. Persisted.
+    @Published var extraCool: Bool = UserDefaults.standard.bool(forKey: "extraCool") {
+        didSet {
+            UserDefaults.standard.set(extraCool, forKey: "extraCool")
+            applyProfile(baseProfile)
+            TFLogger.shared.profile("Extra Cool \(extraCool ? "ON" : "off")")
+        }
+    }
     @Published var launchAtLogin: Bool = false {
         didSet { updateLoginItem() }
     }
@@ -25,6 +33,8 @@ final class AppState: ObservableObject {
     private var monitor: ThermalMonitor?
     private let executor = PrivilegedExecutor()
     private var heartbeatTimer: Timer?
+    /// The profile the user picked, before any Extra Cool transform.
+    private var baseProfile: FanProfile = .silent
 
     init() {
         launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -84,14 +94,13 @@ final class AppState: ObservableObject {
     // MARK: - Actions
 
     func setSmart() {
-        activeProfile = .smart
-        monitor?.switchProfile(.smart)
-        TFLogger.shared.profile("Smart activated")
+        applyProfile(.smart)
     }
 
     func resetAuto() {
         do {
             try executor.execute(.resetAuto)
+            baseProfile = .silent
             activeProfile = .silent
             monitor?.switchProfile(.silent)
             TFLogger.shared.profile("Reset to Default (Silent (Apple Default))")
@@ -101,20 +110,30 @@ final class AppState: ObservableObject {
     }
 
     func selectProfile(_ profile: FanProfile) {
-        activeProfile = profile
-        monitor?.switchProfile(profile)
-        TFLogger.shared.profile("Selected: \(profile.name)")
+        applyProfile(profile)
+    }
+
+    /// Apply a base profile, transforming it through Extra Cool when enabled.
+    /// `Silent` is hands-off and ignores Extra Cool.
+    private func applyProfile(_ base: FanProfile) {
+        baseProfile = base
+        activeProfile = base
+        let effective = extraCool ? base.extraCool() : base
+        monitor?.switchProfile(effective)
+
+        let cool = (extraCool && !base.curve.handsOff) ? " (Extra Cool)" : ""
+        TFLogger.shared.profile("Selected: \(base.name)\(cool)")
 
         // All profiles use proportional curves — tick() handles fan engagement.
         // Reset to auto on profile change so tick() starts from a clean state.
         do {
-            if profile.curve.handsOff || profile.id == "smart" || profile.id == "silent" {
+            if base.curve.handsOff || base.id == "smart" || base.id == "silent" {
                 try executor.execute(.resetAuto)
             }
             // Balanced/Performance/Max: tick() will ramp proportionally
             // based on current temperature after sustained trigger is met
         } catch {
-            TFLogger.shared.error("Profile \(profile.name) failed: \(error)")
+            TFLogger.shared.error("Profile \(base.name) failed: \(error)")
         }
     }
 

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -18,7 +18,11 @@ final class AppState: ObservableObject {
     @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
         didSet { UserDefaults.standard.set(useFahrenheit, forKey: "useFahrenheit") }
     }
-    /// Extra Cool: shift every active profile colder-but-louder. Persisted.
+    /// Extra Cool: a sticky modifier that shifts the active profile colder and
+    /// louder. The toggle is persisted; the *selected profile* deliberately is
+    /// not — the app always starts in Silent (hands-off) on launch for safety,
+    /// so a restored `true` here simply takes effect the moment a profile is
+    /// chosen.
     @Published var extraCool: Bool = UserDefaults.standard.bool(forKey: "extraCool") {
         didSet {
             UserDefaults.standard.set(extraCool, forKey: "extraCool")
@@ -124,14 +128,14 @@ final class AppState: ObservableObject {
         let cool = (extraCool && !base.curve.handsOff) ? " (Extra Cool)" : ""
         TFLogger.shared.profile("Selected: \(base.name)\(cool)")
 
-        // All profiles use proportional curves — tick() handles fan engagement.
-        // Reset to auto on profile change so tick() starts from a clean state.
+        // Reset the hardware to auto on every (re)apply. switchProfile() above
+        // resets the monitor's fan state to "off", so without this the daemon
+        // could keep the fans at a stale manual RPM while the monitor believes
+        // they are off — e.g. when toggling Extra Cool shifts the start
+        // threshold past the current temperature. tick() re-engages within one
+        // cycle, so the only cost is a brief return to Apple's curve.
         do {
-            if base.curve.handsOff || base.id == "smart" || base.id == "silent" {
-                try executor.execute(.resetAuto)
-            }
-            // Balanced/Performance/Max: tick() will ramp proportionally
-            // based on current temperature after sustained trigger is met
+            try executor.execute(.resetAuto)
         } catch {
             TFLogger.shared.error("Profile \(base.name) failed: \(error)")
         }

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -121,6 +121,8 @@ struct MenuBarView: View {
             Divider().padding(.vertical, 4)
 
             // Footer
+            Toggle("Extra Cool", isOn: $appState.extraCool)
+                .padding(.horizontal, 12)
             Toggle("°F / °C", isOn: $appState.useFahrenheit)
                 .padding(.horizontal, 12)
             Toggle("Launch at Login", isOn: $appState.launchAtLogin)

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -69,21 +69,24 @@ struct MenuBarView: View {
                 }
             )) {
                 ForEach(FanProfile.builtIn) { profile in
+                    // When Extra Cool is on, show the effective (transformed)
+                    // thresholds so the row matches what the fans will do.
+                    let shown = appState.extraCool ? profile.extraCool() : profile
                     HStack {
                         Text(profile.name)
                         Spacer()
-                        if !profile.curve.handsOff {
+                        if !shown.curve.handsOff {
                             let unit = appState.useFahrenheit ? "F" : "C"
-                            if profile.curve.instantEngage {
+                            if shown.curve.instantEngage {
                                 // Max: show instant trigger temp
-                                let startC = profile.curve.startTemp
+                                let startC = shown.curve.startTemp
                                 let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
                                 Text("\(Int(startDisp))°\(unit) instant")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             } else {
-                                let startC = profile.curve.startTemp
-                                let ceilC = profile.curve.ceilingTemp
+                                let startC = shown.curve.startTemp
+                                let ceilC = shown.curve.ceilingTemp
                                 let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
                                 let ceilDisp = appState.useFahrenheit ? ceilC * 9 / 5 + 32 : ceilC
                                 Text("\(Int(startDisp))→\(Int(ceilDisp))°\(unit)")

--- a/Sources/ThermalForgeCore/Profile.swift
+++ b/Sources/ThermalForgeCore/Profile.swift
@@ -273,3 +273,42 @@ extension FanProfile {
     /// Hysteresis deadband to prevent oscillation
     public static let hysteresisDegrees: Float = 5.0
 }
+
+// MARK: - Extra Cool
+
+extension FanProfile {
+    /// Returns a colder-but-louder variant of this profile.
+    ///
+    /// Fans engage sooner (lower start/stop), reach full speed at a lower
+    /// temperature (lower ceiling), are allowed a higher ceiling RPM, react
+    /// faster (shorter sustained trigger), and ramp up quicker. Hysteresis gap
+    /// and curve shape are preserved. `Silent` is hands-off (Apple controls the
+    /// fans) so it is returned unchanged.
+    public func extraCool() -> FanProfile {
+        guard !curve.handsOff else { return self }
+
+        // Note: `Swift.max`/`Swift.min` are qualified because `FanProfile.max`
+        // (the Max profile) shadows the free `max` function inside this type.
+        let c = curve
+        let coolStart = Swift.max(c.startTemp - 8, 40)
+        let coolStop  = Swift.max(c.stopTemp  - 8, 35)
+        // Ceiling eased to -7 (was -10) so it reaches full speed a touch later —
+        // colder than stock, but not slamming to max over a brief blip.
+        let coolCeil  = Swift.max(c.ceilingTemp - 7, coolStart + 5)
+        let louder    = Swift.min(c.maxRPMPercent + 0.20, 1.0)
+        let quicker   = Swift.max(c.sustainedTriggerSec * 0.5, 1)
+        let fasterUp  = Swift.min(c.rampUpPerSec * 1.5, 1.0)
+        // Ramp down twice as fast too, so fans calm quickly once temps drop
+        // instead of lingering loud after a spike.
+        let fasterDown = Swift.min(c.rampDownPerSec * 2.0, 1.0)
+
+        let cooled = Curve(
+            stopTemp: coolStop, startTemp: coolStart, ceilingTemp: coolCeil,
+            maxRPMPercent: louder, handsOff: c.handsOff, alwaysOn: c.alwaysOn,
+            curveShape: c.curveShape, rampUpPerSec: fasterUp,
+            rampDownPerSec: fasterDown, sustainedTriggerSec: quicker,
+            instantEngage: c.instantEngage
+        )
+        return FanProfile(id: id, name: name, curve: cooled)
+    }
+}

--- a/Sources/ThermalForgeCore/Profile.swift
+++ b/Sources/ThermalForgeCore/Profile.swift
@@ -277,30 +277,45 @@ extension FanProfile {
 // MARK: - Extra Cool
 
 extension FanProfile {
+    /// Tunable policy for the Extra Cool transform — centralized so the
+    /// colder/louder trade-off is reviewable in one place (and matches the
+    /// unit-test expectations).
+    private enum ExtraCoolPolicy {
+        static let startDrop: Float = 8       // engage this many °C sooner
+        static let stopDrop: Float = 8        // turn off this many °C sooner (keeps the hysteresis gap)
+        static let ceilingDrop: Float = 7     // reach full speed this many °C sooner
+        static let rpmBoost: Float = 0.20     // raise the RPM ceiling (clamped to 1.0)
+        static let triggerScale: Float = 0.5  // react in half the sustained-trigger time
+        static let rampUpScale: Float = 1.5   // ramp up faster
+        static let rampDownScale: Float = 2.0 // ramp down faster, so fans calm quickly after a spike
+        static let minStart: Float = 40       // floor for the start temp
+        static let minStop: Float = 35        // floor for the stop temp
+        static let minCeilingGap: Float = 5   // ceiling stays at least this far above start
+    }
+
     /// Returns a colder-but-louder variant of this profile.
     ///
     /// Fans engage sooner (lower start/stop), reach full speed at a lower
     /// temperature (lower ceiling), are allowed a higher ceiling RPM, react
-    /// faster (shorter sustained trigger), and ramp up quicker. Hysteresis gap
-    /// and curve shape are preserved. `Silent` is hands-off (Apple controls the
-    /// fans) so it is returned unchanged.
+    /// faster (shorter sustained trigger), and ramp up faster while ramping
+    /// down faster so they calm quickly. Hysteresis gap and curve shape are
+    /// preserved. `Silent` is hands-off (Apple controls the fans) so it is
+    /// returned unchanged.
     public func extraCool() -> FanProfile {
         guard !curve.handsOff else { return self }
 
-        // Note: `Swift.max`/`Swift.min` are qualified because `FanProfile.max`
+        // `Swift.max`/`Swift.min` are qualified because `FanProfile.max`
         // (the Max profile) shadows the free `max` function inside this type.
+        typealias P = ExtraCoolPolicy
         let c = curve
-        let coolStart = Swift.max(c.startTemp - 8, 40)
-        let coolStop  = Swift.max(c.stopTemp  - 8, 35)
-        // Ceiling eased to -7 (was -10) so it reaches full speed a touch later —
-        // colder than stock, but not slamming to max over a brief blip.
-        let coolCeil  = Swift.max(c.ceilingTemp - 7, coolStart + 5)
-        let louder    = Swift.min(c.maxRPMPercent + 0.20, 1.0)
-        let quicker   = Swift.max(c.sustainedTriggerSec * 0.5, 1)
-        let fasterUp  = Swift.min(c.rampUpPerSec * 1.5, 1.0)
-        // Ramp down twice as fast too, so fans calm quickly once temps drop
-        // instead of lingering loud after a spike.
-        let fasterDown = Swift.min(c.rampDownPerSec * 2.0, 1.0)
+        let coolStart = Swift.max(c.startTemp - P.startDrop, P.minStart)
+        let coolStop  = Swift.max(c.stopTemp - P.stopDrop, P.minStop)
+        // Keep the ceiling above the start temp so the proportional zone stays valid.
+        let coolCeil  = Swift.max(c.ceilingTemp - P.ceilingDrop, coolStart + P.minCeilingGap)
+        let louder    = Swift.min(c.maxRPMPercent + P.rpmBoost, 1.0)
+        let quicker   = Swift.max(c.sustainedTriggerSec * P.triggerScale, 1)
+        let fasterUp  = Swift.min(c.rampUpPerSec * P.rampUpScale, 1.0)
+        let fasterDown = Swift.min(c.rampDownPerSec * P.rampDownScale, 1.0)
 
         let cooled = Curve(
             stopTemp: coolStop, startTemp: coolStart, ceilingTemp: coolCeil,

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -276,15 +276,13 @@ public final class ThermalMonitor {
 
     // MARK: - Smart Profile
 
-    /// Target temperature ceiling — keep below this to avoid any throttling
-    private static let smartCeiling: Float = 85.0
-    /// Smart starts earlier than other profiles to get ahead of rising temps
-    private static let smartFloor: Float = 53.0
-
-    /// All profiles share the same off threshold — 50°C matches Apple's observed stop range
-    private static let smartStopTemp: Float = 50.0
-
     private func tickSmart(status: ThermalStatus, peakTemp: Float) {
+        // Smart thresholds are read from the active profile's curve, so the
+        // Extra Cool transform (lower start/stop/ceiling) shifts Smart too.
+        let stop = activeProfile.curve.stopTemp        // off threshold
+        let floor = activeProfile.curve.startTemp      // fans engage above this
+        let ceiling = activeProfile.curve.ceilingTemp  // full speed at/above this
+
         // Sample temperature history at monitor cadence (2s) for stable rate-of-change
         if tickCounter % Self.monitorCadence == 0 {
             tempHistory.append(peakTemp)
@@ -296,22 +294,22 @@ public final class ThermalMonitor {
         let minPct = minRPM / maxRPM
 
         // Below stop threshold and fans running: turn off (with hysteresis)
-        if peakTemp < Self.smartStopTemp && fansCurrentlyRunning && rateOfChange() <= 0 {
+        if peakTemp < stop && fansCurrentlyRunning && rateOfChange() <= 0 {
             applyCommand(.resetAuto)
             lastAppliedRPMPercent = 0
             fansCurrentlyRunning = false
             state = .idle
-            TFLogger.shared.fan("Smart fans off: \(String(format: "%.1f", peakTemp))°C below \(Int(Self.smartStopTemp))°C")
+            TFLogger.shared.fan("Smart fans off: \(String(format: "%.1f", peakTemp))°C below \(Int(stop))°C")
             return
         }
 
         // Below floor and fans not running: stay off
-        if peakTemp < Self.smartFloor && !fansCurrentlyRunning {
+        if peakTemp < floor && !fansCurrentlyRunning {
             return
         }
 
         // In hysteresis band (50-53°C): maintain current state
-        if peakTemp >= Self.smartStopTemp && peakTemp < Self.smartFloor && !fansCurrentlyRunning {
+        if peakTemp >= stop && peakTemp < floor && !fansCurrentlyRunning {
             return
         }
 
@@ -333,13 +331,13 @@ public final class ThermalMonitor {
 
             if rate > 0 {
                 // Rising: boost proportionally to rate and proximity to ceiling
-                let urgency = min(max((peakTemp - Self.smartFloor) / (Self.smartCeiling - Self.smartFloor), 0), 1)
+                let urgency = min(max((peakTemp - floor) / (ceiling - floor), 0), 1)
                 targetPct = min(targetPct + rate * 0.15 * (1 + urgency), 1.0)
             }
         } else {
             // Uncalibrated: S-curve (matches profile curveShape)
-            let range = Self.smartCeiling - Self.smartFloor
-            let position = min(max((peakTemp - Self.smartFloor) / range, 0), 1)
+            let range = ceiling - floor
+            let position = min(max((peakTemp - floor) / range, 0), 1)
             targetPct = position * position * (3 - 2 * position)
 
             if rate > 0 {
@@ -347,7 +345,7 @@ public final class ThermalMonitor {
             }
         }
 
-        if peakTemp > Self.smartCeiling {
+        if peakTemp > ceiling {
             targetPct = 1.0
         }
 

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -229,7 +229,12 @@ struct Watch: ParsableCommand {
         let fc = try FanControl()
         let monitor = ThermalMonitor(fanControl: fc, profile: selectedProfile)
 
-        print("ThermalForge watch — profile: \(selectedProfile.name)")
+        let label = extraCool ? "\(selectedProfile.name) (Extra Cool)" : selectedProfile.name
+        print("ThermalForge watch — profile: \(label)")
+        if !selectedProfile.curve.handsOff {
+            let cu = selectedProfile.curve
+            print("Curve: start \(Int(cu.startTemp))°C → ceiling \(Int(cu.ceilingTemp))°C, max \(Int(cu.maxRPMPercent * 100))%")
+        }
         print("Hardware: \(fc.hardwareInfo)")
         print("Polling every \(interval)s. Ctrl-C to stop.\n")
 

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -214,13 +214,17 @@ struct Watch: ParsableCommand {
     @Flag(name: .long, help: "Output JSON on each update")
     var json: Bool = false
 
+    @Flag(name: .long, help: "Extra Cool: shift the curve colder and raise max fan (louder)")
+    var extraCool: Bool = false
+
     func run() throws {
         let profiles = FanProfile.builtIn
-        guard let selectedProfile = profiles.first(where: { $0.id == profile }) else {
+        guard let base = profiles.first(where: { $0.id == profile }) else {
             throw ValidationError(
                 "Unknown profile '\(profile)'. Options: \(profiles.map(\.id).joined(separator: ", "))"
             )
         }
+        let selectedProfile = extraCool ? base.extraCool() : base
 
         let fc = try FanControl()
         let monitor = ThermalMonitor(fanControl: fc, profile: selectedProfile)

--- a/Tests/ThermalForgeTests/ProfileTests.swift
+++ b/Tests/ThermalForgeTests/ProfileTests.swift
@@ -157,6 +157,55 @@ struct ProfileTests {
         #expect(FanProfile.silent.extraCool() == FanProfile.silent)
     }
 
+    @Test("Extra Cool transforms Performance: colder, louder, faster")
+    func extraCoolPerformance() {
+        let p = FanProfile.performance.extraCool()
+        #expect(p.id == "performance")
+        #expect(p.curve.startTemp == 47)                     // 55 - 8
+        #expect(p.curve.stopTemp == 42)                      // 50 - 8
+        #expect(p.curve.ceilingTemp == 58)                   // 65 - 7
+        #expect(p.curve.maxRPMPercent == 1.0)                // 0.85 + 0.20 -> clamped to 1.0
+        #expect(p.curve.sustainedTriggerSec == 2)            // 4 * 0.5
+        #expect(abs(p.curve.rampUpPerSec - 0.15) < 0.0001)   // 0.10 * 1.5
+        #expect(abs(p.curve.rampDownPerSec - 0.08) < 0.0001) // 0.04 * 2
+        #expect(p.curve.curveShape == .linear)
+    }
+
+    @Test("Extra Cool keeps Max instant-engage valid and engages 8°C sooner")
+    func extraCoolMax() {
+        let m = FanProfile.max.extraCool()
+        #expect(m.curve.instantEngage == true)
+        #expect(m.curve.startTemp == 57)                     // 65 - 8
+        #expect(m.curve.stopTemp == 42)                      // 50 - 8
+        // Ceiling is floored to start + 5 so the proportional zone never inverts
+        #expect(m.curve.ceilingTemp >= m.curve.startTemp + 5)
+        #expect(m.curve.maxRPMPercent == 1.0)
+        #expect(m.curve.sustainedTriggerSec == 2.5)          // 5 * 0.5
+        // Instant engage: jumps straight to max at the new (lower) start temp,
+        // and stays off just below it (hysteresis band).
+        #expect(m.curve.targetPercent(at: 57, fansCurrentlyRunning: false) == 1.0)
+        #expect(m.curve.targetPercent(at: 56, fansCurrentlyRunning: false) == nil)
+    }
+
+    @Test("Extra Cool preserves id and name for every profile")
+    func extraCoolPreservesIdentity() {
+        for p in [FanProfile.silent, .balanced, .performance, .max, .smart] {
+            let c = p.extraCool()
+            #expect(c.id == p.id, "id changed for \(p.name)")
+            #expect(c.name == p.name, "name changed for \(p.name)")
+        }
+    }
+
+    @Test("Smart curve matches the thresholds tickSmart reads (toggle-off equivalence)")
+    func smartCurveMatchesMonitorThresholds() {
+        // tickSmart now reads floor/ceiling/stop from the active profile's curve
+        // instead of hardcoded constants. These must equal the prior constants
+        // so Smart behaves identically when Extra Cool is OFF.
+        #expect(FanProfile.smart.curve.stopTemp == 50)
+        #expect(FanProfile.smart.curve.startTemp == 53)
+        #expect(FanProfile.smart.curve.ceilingTemp == 85)
+    }
+
     // MARK: - Curve Shape Behavior
 
     @Test("Balanced ease-in curve: quiet at low temps, ramps harder at high")

--- a/Tests/ThermalForgeTests/ProfileTests.swift
+++ b/Tests/ThermalForgeTests/ProfileTests.swift
@@ -117,6 +117,46 @@ struct ProfileTests {
         #expect(FanProfile.hysteresisDegrees == 5.0)
     }
 
+    // MARK: - Extra Cool
+
+    @Test("Extra Cool shifts Balanced colder and louder, preserving identity")
+    func extraCoolBalanced() {
+        let cooled = FanProfile.balanced.extraCool()
+
+        // Identity preserved so the UI picker selection still matches
+        #expect(cooled.id == "balanced")
+        #expect(cooled.name == "Balanced")
+
+        // Colder: start/stop/ceiling each shift down
+        #expect(cooled.curve.startTemp == 47)    // 55 - 8
+        #expect(cooled.curve.stopTemp == 42)     // 50 - 8 (5°C hysteresis kept)
+        #expect(cooled.curve.ceilingTemp == 63)  // 70 - 7
+
+        // Louder + more responsive
+        #expect(abs(cooled.curve.maxRPMPercent - 0.80) < 0.0001) // 0.60 + 0.20
+        #expect(cooled.curve.sustainedTriggerSec == 4)           // 8 * 0.5
+        #expect(abs(cooled.curve.rampUpPerSec - 0.075) < 0.0001) // 0.05 * 1.5
+        #expect(abs(cooled.curve.rampDownPerSec - 0.05) < 0.0001) // 0.025 * 2 (calms faster)
+
+        // Shape unchanged
+        #expect(cooled.curve.curveShape == .easeIn)
+        // Hysteresis gap preserved
+        #expect(cooled.curve.startTemp - cooled.curve.stopTemp == 5)
+    }
+
+    @Test("Extra Cool caps max RPM at 100% and leaves Silent untouched")
+    func extraCoolCapsAndSilent() {
+        // Max is already 100% — Extra Cool must not exceed 1.0
+        #expect(FanProfile.max.extraCool().curve.maxRPMPercent == 1.0)
+
+        // Smart shifts its ceiling down so it reaches full speed sooner
+        #expect(FanProfile.smart.extraCool().curve.ceilingTemp == 78) // 85 - 7
+        #expect(FanProfile.smart.extraCool().curve.startTemp == 45)    // 53 - 8
+
+        // Silent is hands-off — Extra Cool is a no-op
+        #expect(FanProfile.silent.extraCool() == FanProfile.silent)
+    }
+
     // MARK: - Curve Shape Behavior
 
     @Test("Balanced ease-in curve: quiet at low temps, ramps harder at high")


### PR DESCRIPTION
## What
Adds an opt-in **Extra Cool** toggle that makes any profile run colder at the cost of more noise, without altering the stock profiles.

## Why
Some setups (laptops in warm rooms, sustained workloads) want every profile shifted toward cooler operation without hand-rolling a custom curve. Extra Cool is a single switch that does this consistently across all profiles.

## How
A curve transform applied to whichever profile is active:
- lower start / stop / ceiling temps (engage sooner, full speed sooner)
- raise the RPM ceiling (+20 %, clamped to 100 %)
- shorter sustained trigger (react faster)
- ramp **up** 1.5× faster, ramp **down** 2× faster — so fans calm quickly once temps drop instead of lingering loud after a spike
- `Silent` is hands-off and passes through unchanged

To let Extra Cool also reach **Smart**, Smart now reads its floor / ceiling / stop thresholds from the active profile's curve instead of hardcoded constants. The values are identical for the stock Smart profile, so behavior is unchanged when the toggle is off.

Exposed as a persisted checkbox in the menu bar and a `--extra-cool` flag on `watch`.

## Testing
- `swift build -c release` ✅
- `swift test` ✅ (26 tests — 2 new, covering the transform math, the RPM cap, and the `Silent` no-op)
- Verified on M1 Max: toggling Extra Cool live re-applies the transform; Balanced + Extra Cool holds the chip cooler with a modest noise increase.
