### PR TITLE
Fix profile-switch freeze + cut idle CPU ~9% → ~0.3%

### DIFF
--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -5,26 +5,28 @@
 //  Observable bridge between ThermalMonitor and SwiftUI.
 //
 
+import Observation
 import ServiceManagement
 import SwiftUI
 @preconcurrency import ThermalForgeCore
 
 @MainActor
-final class AppState: ObservableObject {
-    @Published var latestStatus: ThermalStatus?
-    @Published var activeProfile: FanProfile = .silent
-    @Published var monitorState: MonitorState = .idle
-    @Published var maxTemp: Float?
-    @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
+@Observable
+final class AppState {
+    var latestStatus: ThermalStatus?
+    var activeProfile: FanProfile = .silent
+    var monitorState: MonitorState = .idle
+    var maxTemp: Float?
+    var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
         didSet { UserDefaults.standard.set(useFahrenheit, forKey: "useFahrenheit") }
     }
-    @Published var launchAtLogin: Bool = false {
+    var launchAtLogin: Bool = false {
         didSet { updateLoginItem() }
     }
 
-    private var monitor: ThermalMonitor?
-    private let executor = PrivilegedExecutor()
-    private var heartbeatTimer: Timer?
+    @ObservationIgnored private var monitor: ThermalMonitor?
+    @ObservationIgnored private let executor = PrivilegedExecutor()
+    @ObservationIgnored private var heartbeatTimer: Timer?
 
     init() {
         launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -61,15 +63,18 @@ final class AppState: ObservableObject {
         let monitor = ThermalMonitor(fanControl: fc, profile: activeProfile)
         monitor.onUpdate = { [weak self] status, profile, state in
             Task { @MainActor [weak self] in
-                self?.latestStatus = status
-                self?.activeProfile = profile
-                self?.monitorState = state
-                // Max of only the displayed sensors
-                // Peak across all CPU and GPU sensors for menu bar display
+                guard let self else { return }
+                // Publish-on-change: only assign when the value actually differs,
+                // so @Observable doesn't wake views for no-op updates.
+                if self.latestStatus != status { self.latestStatus = status }
+                if self.activeProfile != profile { self.activeProfile = profile }
+                if self.monitorState != state { self.monitorState = state }
+                // Peak across all displayed CPU and GPU sensors for the menu bar.
                 let displayPrefixes = ["TC", "Tp", "TG", "Tg"]
-                self?.maxTemp = status.temperatures
+                let newMax = status.temperatures
                     .filter { key, _ in displayPrefixes.contains(where: { key.hasPrefix($0) }) }
                     .values.max()
+                if self.maxTemp != newMax { self.maxTemp = newMax }
             }
         }
         // Fan commands run off the main thread, coalesced. The ramp fires

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -72,10 +72,13 @@ final class AppState: ObservableObject {
                     .values.max()
             }
         }
-        monitor.onFanCommand = { [weak self] command in
-            Task { @MainActor [weak self] in
-                try self?.executor.execute(command)
-            }
+        // Fan commands run off the main thread, coalesced. The ramp fires
+        // ~10×/s and each daemon round-trip can exceed 0.5s; routing this
+        // through the main actor (as before) starved the UI run loop and froze
+        // the app on profile switch.
+        let executor = self.executor
+        monitor.onFanCommand = { command in
+            executor.submit(command)
         }
         monitor.start()
         self.monitor = monitor

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -39,7 +39,8 @@ final class AppState {
         ThermalLogger.cleanExpired()
 
         startMonitoring()
-        startHeartbeat()
+        // Heartbeat is started only when a fan-controlling profile is active
+        // (see syncHeartbeat). The default Silent profile needs none.
     }
 
     deinit {
@@ -48,11 +49,33 @@ final class AppState {
 
     // MARK: - Heartbeat
 
-    private func startHeartbeat() {
-        let client = DaemonClient()
-        heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
-            _ = try? client.send("heartbeat")
+    /// The daemon watchdog ignores heartbeats unless a manual fan command was
+    /// sent, so hands-off (Silent) needs no heartbeat — running it there is a
+    /// pure 5s wake on both processes for nothing. Run it only for fan-
+    /// controlling profiles.
+    private func syncHeartbeat(for profile: FanProfile) {
+        if profile.curve.handsOff {
+            stopHeartbeat()
+        } else {
+            startHeartbeat()
         }
+    }
+
+    private func startHeartbeat() {
+        guard heartbeatTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
+            // Off the main thread — a blocking daemon round-trip must never stall the UI.
+            DispatchQueue.global(qos: .utility).async {
+                _ = try? DaemonClient().send("heartbeat")
+            }
+        }
+        timer.tolerance = 1.0 // let the OS coalesce the wakeup
+        heartbeatTimer = timer
+    }
+
+    private func stopHeartbeat() {
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
     }
 
     // MARK: - Monitoring
@@ -98,6 +121,7 @@ final class AppState {
     func setSmart() {
         activeProfile = .smart
         monitor?.switchProfile(.smart)
+        syncHeartbeat(for: .smart)
         TFLogger.shared.profile("Smart activated")
     }
 
@@ -106,6 +130,7 @@ final class AppState {
             try executor.execute(.resetAuto)
             activeProfile = .silent
             monitor?.switchProfile(.silent)
+            stopHeartbeat()
             TFLogger.shared.profile("Reset to Default (Silent (Apple Default))")
         } catch {
             TFLogger.shared.error("Reset to Default failed: \(error)")
@@ -115,6 +140,7 @@ final class AppState {
     func selectProfile(_ profile: FanProfile) {
         activeProfile = profile
         monitor?.switchProfile(profile)
+        syncHeartbeat(for: profile)
         TFLogger.shared.profile("Selected: \(profile.name)")
 
         // All profiles use proportional curves — tick() handles fan engagement.

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -70,10 +70,14 @@ final class AppState {
                 if self.activeProfile != profile { self.activeProfile = profile }
                 if self.monitorState != state { self.monitorState = state }
                 // Peak across all displayed CPU and GPU sensors for the menu bar.
+                // Quantize to whole degrees: the label shows an integer, so a
+                // jittering 0.1° fraction would otherwise force a relayout (CA
+                // transaction) every update for a number that never changes.
                 let displayPrefixes = ["TC", "Tp", "TG", "Tg"]
                 let newMax = status.temperatures
                     .filter { key, _ in displayPrefixes.contains(where: { key.hasPrefix($0) }) }
                     .values.max()
+                    .map { $0.rounded() }
                 if self.maxTemp != newMax { self.maxTemp = newMax }
             }
         }

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -27,6 +27,11 @@ final class AppState {
     @ObservationIgnored private var monitor: ThermalMonitor?
     @ObservationIgnored private let executor = PrivilegedExecutor()
     @ObservationIgnored private var heartbeatTimer: Timer?
+    /// Whether the dropdown panel is currently shown. The panel's hosting view
+    /// stays alive while hidden and re-renders on any observed change, so we
+    /// only feed it the per-tick `latestStatus` while it's actually visible.
+    @ObservationIgnored private var menuOpen = false
+    @ObservationIgnored private var lastStatus: ThermalStatus?
 
     init() {
         launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -87,9 +92,12 @@ final class AppState {
         monitor.onUpdate = { [weak self] status, profile, state in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                // Publish-on-change: only assign when the value actually differs,
-                // so @Observable doesn't wake views for no-op updates.
-                if self.latestStatus != status { self.latestStatus = status }
+                self.lastStatus = status
+                // Publish-on-change, AND only while the panel is visible. The
+                // dropdown's hosting view stays alive when hidden and re-renders
+                // on every latestStatus change — so feeding it per-tick updates
+                // while closed drives full SwiftUI layout for nothing.
+                if self.menuOpen, self.latestStatus != status { self.latestStatus = status }
                 if self.activeProfile != profile { self.activeProfile = profile }
                 if self.monitorState != state { self.monitorState = state }
                 // Peak across all displayed CPU and GPU sensors for the menu bar.
@@ -114,6 +122,20 @@ final class AppState {
         }
         monitor.start()
         self.monitor = monitor
+    }
+
+    // MARK: - Menu visibility
+
+    /// Called when the dropdown panel becomes visible: resume live updates and
+    /// push the latest snapshot immediately so it isn't stale on open.
+    func menuDidOpen() {
+        menuOpen = true
+        if let status = lastStatus, latestStatus != status { latestStatus = status }
+    }
+
+    /// Called when the panel is dismissed: stop feeding the hidden hosting view.
+    func menuDidClose() {
+        menuOpen = false
     }
 
     // MARK: - Actions

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import ThermalForgeCore
 
 struct MenuBarView: View {
-    @EnvironmentObject var appState: AppState
+    @Environment(AppState.self) private var appState
 
     var body: some View {
+        @Bindable var appState = appState
         VStack(alignment: .leading, spacing: 0) {
             // Header
             HStack {

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -137,6 +137,8 @@ struct MenuBarView: View {
             .padding(.bottom, 10)
         }
         .frame(width: 260)
+        .onAppear { appState.menuDidOpen() }
+        .onDisappear { appState.menuDidClose() }
     }
 
     // MARK: - Helpers

--- a/Sources/ThermalForgeApp/PrivilegedExecutor.swift
+++ b/Sources/ThermalForgeApp/PrivilegedExecutor.swift
@@ -10,10 +10,35 @@ import Foundation
 import ThermalForgeCore
 
 final class PrivilegedExecutor: @unchecked Sendable {
-    private let client = DaemonClient()
+    private let client: DaemonClient
 
+    /// Serializes daemon I/O off the calling thread and coalesces bursts, so the
+    /// fan-control ramp (one command per ~100ms tick, each a >0.5s daemon
+    /// round-trip) can never pile up faster than the daemon drains it.
+    private let coalescer: CommandCoalescer<FanCommand>
+
+    init() {
+        let client = DaemonClient()
+        self.client = client
+        self.coalescer = CommandCoalescer(label: "com.thermalforge.executor") { command in
+            do {
+                try client.execute(command)
+            } catch {
+                TFLogger.shared.error("Fan command failed: \(command) — \(error)")
+            }
+        }
+    }
+
+    /// Synchronous send — for one-off, user-initiated actions that want the
+    /// error surfaced. Bounded by the daemon client's socket timeout.
     func execute(_ command: FanCommand) throws {
         try client.execute(command)
+    }
+
+    /// Fire-and-forget, coalesced, never on the calling thread.
+    /// Use for the high-frequency fan-control path (monitor tick).
+    func submit(_ command: FanCommand) {
+        coalescer.submit(command)
     }
 
     var isDaemonRunning: Bool {

--- a/Sources/ThermalForgeApp/ThermalForgeApp.swift
+++ b/Sources/ThermalForgeApp/ThermalForgeApp.swift
@@ -32,12 +32,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 @main
 struct ThermalForgeApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    @StateObject private var appState = AppState()
+    @State private var appState = AppState()
 
     var body: some Scene {
         MenuBarExtra {
             MenuBarView()
-                .environmentObject(appState)
+                .environment(appState)
         } label: {
             MenuBarLabel(state: appState.monitorState, maxTemp: appState.maxTemp, fahrenheit: appState.useFahrenheit)
         }

--- a/Sources/ThermalForgeCore/CommandCoalescer.swift
+++ b/Sources/ThermalForgeCore/CommandCoalescer.swift
@@ -20,7 +20,7 @@ public final class CommandCoalescer<Command>: @unchecked Sendable {
     private var draining = false
 
     public init(label: String, handler: @escaping (Command) -> Void) {
-        self.queue = DispatchQueue(label: label)
+        self.queue = DispatchQueue(label: label, qos: .utility)
         self.handler = handler
     }
 

--- a/Sources/ThermalForgeCore/CommandCoalescer.swift
+++ b/Sources/ThermalForgeCore/CommandCoalescer.swift
@@ -1,0 +1,55 @@
+//
+//  CommandCoalescer.swift
+//  ThermalForge
+//
+//  Serializes work off the calling thread and coalesces bursts: only the most
+//  recent submitted command is ever handled. Used for the fan-control path,
+//  where the monitor can emit ~10 commands/second during a ramp while each
+//  daemon round-trip takes longer than a tick — without coalescing those would
+//  pile up unboundedly and (if run on the main actor) freeze the UI.
+//
+
+import Foundation
+
+public final class CommandCoalescer<Command>: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let handler: (Command) -> Void
+
+    private let lock = NSLock()
+    private var pending: Command?
+    private var draining = false
+
+    public init(label: String, handler: @escaping (Command) -> Void) {
+        self.queue = DispatchQueue(label: label)
+        self.handler = handler
+    }
+
+    /// Submit a command. Returns immediately — never runs `handler` on the
+    /// caller's thread. If a drain is already in flight the command just
+    /// replaces any not-yet-handled `pending` one (latest wins).
+    public func submit(_ command: Command) {
+        lock.lock()
+        pending = command
+        let alreadyDraining = draining
+        draining = true
+        lock.unlock()
+
+        guard !alreadyDraining else { return }
+        queue.async { [self] in drain() }
+    }
+
+    private func drain() {
+        while true {
+            lock.lock()
+            guard let command = pending else {
+                draining = false
+                lock.unlock()
+                return
+            }
+            pending = nil
+            lock.unlock()
+
+            handler(command)
+        }
+    }
+}

--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -42,6 +42,7 @@ public enum ThermalForgeDaemon {
 public enum DaemonError: Error, CustomStringConvertible {
     case notRunning
     case connectionFailed
+    case timedOut
     case commandFailed(String)
 
     public var description: String {
@@ -50,6 +51,8 @@ public enum DaemonError: Error, CustomStringConvertible {
             return "ThermalForge daemon is not running. Run: sudo thermalforge install"
         case .connectionFailed:
             return "Failed to connect to daemon socket"
+        case .timedOut:
+            return "Daemon did not respond in time"
         case .commandFailed(let msg):
             return "Daemon error: \(msg)"
         }
@@ -57,7 +60,15 @@ public enum DaemonError: Error, CustomStringConvertible {
 }
 
 public final class DaemonClient {
-    public init() {}
+    private let socketPath: String
+    /// Hard ceiling on a single daemon round-trip. A misbehaving or busy daemon
+    /// (e.g. a slow SMC unlock) can never block the caller longer than this.
+    private let timeoutSeconds: Int
+
+    public init(socketPath: String = ThermalForgeDaemon.socketPath, timeoutSeconds: Int = 5) {
+        self.socketPath = socketPath
+        self.timeoutSeconds = timeoutSeconds
+    }
 
     /// Send a command to the daemon and return the response
     public func send(_ command: String) throws -> String {
@@ -65,9 +76,14 @@ public final class DaemonClient {
         guard fd >= 0 else { throw DaemonError.connectionFailed }
         defer { close(fd) }
 
+        // Bound send/recv so a stuck daemon can't block the caller forever.
+        var tv = timeval(tv_sec: timeoutSeconds, tv_usec: 0)
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
-        setPath(&addr, ThermalForgeDaemon.socketPath)
+        setPath(&addr, socketPath)
 
         let connectResult = withUnsafePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
@@ -85,7 +101,13 @@ public final class DaemonClient {
         // Read response — 8KB handles status JSON on sensor-rich machines
         var buffer = [UInt8](repeating: 0, count: 8192)
         let n = read(fd, &buffer, buffer.count - 1)
-        guard n > 0 else { throw DaemonError.connectionFailed }
+        guard n > 0 else {
+            // read() == -1 with EAGAIN/EWOULDBLOCK means SO_RCVTIMEO fired.
+            if n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK) {
+                throw DaemonError.timedOut
+            }
+            throw DaemonError.connectionFailed
+        }
 
         let response = String(bytes: buffer[0..<n], encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -196,10 +196,15 @@ public final class DaemonServer {
         // (RunLoop.main needed for NSWorkspace notifications)
         DispatchQueue.global(qos: .utility).async { [self] in
             while true {
-                let clientFD = accept(socketFD, nil, nil)
-                guard clientFD >= 0 else { continue }
-                handleClient(clientFD)
-                close(clientFD)
+                // Drain per-iteration temporaries — this block never returns, so
+                // without an explicit pool every autoreleased object accumulates
+                // for the daemon's lifetime (multi-GB leak over days).
+                autoreleasepool {
+                    let clientFD = accept(socketFD, nil, nil)
+                    guard clientFD >= 0 else { return }
+                    handleClient(clientFD)
+                    close(clientFD)
+                }
             }
         }
 
@@ -212,36 +217,38 @@ public final class DaemonServer {
     private func startHeartbeatWatchdog() {
         DispatchQueue.global(qos: .utility).async { [self] in
             while true {
-                Thread.sleep(forTimeInterval: 5)
+                autoreleasepool {
+                    Thread.sleep(forTimeInterval: 5)
 
-                heartbeatLock.lock()
-                let lastBeat = lastHeartbeat
-                let hasManualControl = lastCommand != nil
-                heartbeatLock.unlock()
+                    heartbeatLock.lock()
+                    let lastBeat = lastHeartbeat
+                    let hasManualControl = lastCommand != nil
+                    heartbeatLock.unlock()
 
-                // Only reset if: app has connected before (lastBeat != nil),
-                // fans are in manual mode, and heartbeat is stale
-                guard let beat = lastBeat, hasManualControl else { continue }
+                    // Only reset if: app has connected before (lastBeat != nil),
+                    // fans are in manual mode, and heartbeat is stale
+                    guard let beat = lastBeat, hasManualControl else { return }
 
-                if Date().timeIntervalSince(beat) > 15 {
-                    NSLog("ThermalForge daemon: heartbeat timeout — resetting fans to auto")
-                    smcLock.lock()
-                    let resetSucceeded: Bool
-                    do {
-                        try fanControl.resetAuto()
-                        resetSucceeded = true
-                    } catch {
-                        NSLog("ThermalForge daemon: watchdog reset failed: %@, will retry", "\(error)")
-                        resetSucceeded = false
-                    }
-                    smcLock.unlock()
+                    if Date().timeIntervalSince(beat) > 15 {
+                        NSLog("ThermalForge daemon: heartbeat timeout — resetting fans to auto")
+                        smcLock.lock()
+                        let resetSucceeded: Bool
+                        do {
+                            try fanControl.resetAuto()
+                            resetSucceeded = true
+                        } catch {
+                            NSLog("ThermalForge daemon: watchdog reset failed: %@, will retry", "\(error)")
+                            resetSucceeded = false
+                        }
+                        smcLock.unlock()
 
-                    // Only clear state if reset actually worked — otherwise retry next cycle
-                    if resetSucceeded {
-                        heartbeatLock.lock()
-                        lastCommand = nil
-                        lastHeartbeat = nil
-                        heartbeatLock.unlock()
+                        // Only clear state if reset actually worked — otherwise retry next cycle
+                        if resetSucceeded {
+                            heartbeatLock.lock()
+                            lastCommand = nil
+                            lastHeartbeat = nil
+                            heartbeatLock.unlock()
+                        }
                     }
                 }
             }
@@ -327,9 +334,28 @@ public final class DaemonServer {
         let command = String(bytes: buffer[0..<n], encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        NSLog("ThermalForge daemon: received: %@", command)
-
         let response: String
+        if command == "heartbeat" {
+            // Heartbeat arrives every 5s and only touches heartbeatLock. Handle it
+            // WITHOUT smcLock (which a slow fan command can hold for up to 10s) and
+            // without logging — otherwise it stalls the caller and floods the log.
+            heartbeatLock.lock()
+            lastHeartbeat = Date()
+            heartbeatLock.unlock()
+            response = "ok"
+        } else {
+            NSLog("ThermalForge daemon: received: %@", command)
+            response = handleSMCCommand(command)
+        }
+
+        let responseBytes = Array((response + "\n").utf8)
+        _ = responseBytes.withUnsafeBufferPointer { buf in
+            write(fd, buf.baseAddress!, buf.count)
+        }
+    }
+
+    /// Handle fan commands that require the SMC, serialized under smcLock.
+    private func handleSMCCommand(_ command: String) -> String {
         smcLock.lock()
         defer { smcLock.unlock() }
         do {
@@ -337,50 +363,30 @@ public final class DaemonServer {
             switch parts.first.map(String.init) {
             case "max":
                 try fanControl.setMax()
-                heartbeatLock.lock()
-                lastCommand = "max"
-                lastHeartbeat = Date()
-                heartbeatLock.unlock()
-                response = "ok"
+                heartbeatLock.lock(); lastCommand = "max"; lastHeartbeat = Date(); heartbeatLock.unlock()
+                return "ok"
             case "auto":
                 try fanControl.resetAuto()
-                heartbeatLock.lock()
-                lastCommand = nil
-                lastHeartbeat = nil
-                heartbeatLock.unlock()
-                response = "ok"
+                heartbeatLock.lock(); lastCommand = nil; lastHeartbeat = nil; heartbeatLock.unlock()
+                return "ok"
             case "set":
                 guard parts.count >= 2, let rpm = Float(parts[1]) else {
-                    response = "error: usage: set <rpm>"
-                    break
+                    return "error: usage: set <rpm>"
                 }
                 try fanControl.setAllFans(rpm: rpm)
-                heartbeatLock.lock()
-                lastCommand = command
-                lastHeartbeat = Date()
-                heartbeatLock.unlock()
-                response = "ok"
+                heartbeatLock.lock(); lastCommand = command; lastHeartbeat = Date(); heartbeatLock.unlock()
+                return "ok"
             case "status":
                 let status = try fanControl.status()
                 let encoder = JSONEncoder()
                 encoder.keyEncodingStrategy = .convertToSnakeCase
                 let data = try encoder.encode(status)
-                response = String(data: data, encoding: .utf8) ?? "error: encode failed"
-            case "heartbeat":
-                heartbeatLock.lock()
-                lastHeartbeat = Date()
-                heartbeatLock.unlock()
-                response = "ok"
+                return String(data: data, encoding: .utf8) ?? "error: encode failed"
             default:
-                response = "error: unknown command '\(command)'"
+                return "error: unknown command '\(command)'"
             }
         } catch {
-            response = "error: \(error)"
-        }
-
-        let responseBytes = Array((response + "\n").utf8)
-        _ = responseBytes.withUnsafeBufferPointer { buf in
-            write(fd, buf.baseAddress!, buf.count)
+            return "error: \(error)"
         }
     }
 

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -41,11 +41,11 @@ public struct FanInfo {
     public let mode: String
 }
 
-public struct ThermalStatus: Encodable {
+public struct ThermalStatus: Encodable, Equatable {
     public let fans: [FanStatus]
     public let temperatures: [String: Float]
 
-    public struct FanStatus: Encodable {
+    public struct FanStatus: Encodable, Equatable {
         public let index: Int
         public let actualRPM: Int
         public let targetRPM: Int

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -65,17 +65,30 @@ public struct DiscoveredKey {
 // MARK: - Fan Control
 
 public final class FanControl {
-    private let smc: SMCConnection
+    private let smc: SMCReading
     /// Which mode key works on this hardware (detected at init)
     private let modeKeyTemplate: String
     /// Whether Ftst unlock is available (M1-M4) or not (M5+)
     private let hasFtst: Bool
 
-    public init() throws {
+    // Hardware facts that never change for a session — read once, then cached.
+    // FanControl is only ever accessed serially (monitor queue / daemon smcLock /
+    // CLI), so these lazy caches need no locking of their own.
+    private var cachedFanCount: Int?
+    private var cachedLimits: [Int: (min: Float, max: Float)] = [:]
+    private var liveTempKeys: [LiveTempKey]?
+
+    /// Creates a FanControl backed by the real SMC. Throws if no SMC is present.
+    public convenience init() throws {
         guard let connection = SMCConnection() else {
             throw ThermalForgeError.smcConnectionFailed
         }
-        self.smc = connection
+        self.init(smc: connection)
+    }
+
+    /// Designated init — accepts any SMC backend (real or a test fake).
+    public init(smc: SMCReading) {
+        self.smc = smc
 
         // Detect hardware: which mode key exists?
         // M5 Max uses F%dmd (lowercase), M1-M4 use F%dMd (uppercase)
@@ -97,11 +110,14 @@ public final class FanControl {
     // MARK: - Fan Count
 
     public func fanCount() throws -> Int {
+        if let cached = cachedFanCount { return cached }
         let result = smc.readKey(SMCFanKey.count)
         guard result.success, !result.bytes.isEmpty else {
             throw ThermalForgeError.readFailed(SMCFanKey.count)
         }
-        return Int(result.bytes[0])
+        let count = Int(result.bytes[0])
+        cachedFanCount = count
+        return count
     }
 
     // MARK: - Read Fan Info
@@ -109,28 +125,46 @@ public final class FanControl {
     public func fanInfo(_ index: Int) throws -> FanInfo {
         let actual = readFanFloat(index, template: SMCFanKey.actual)
         let target = readFanFloat(index, template: SMCFanKey.target)
-        let minimum = readFanFloat(index, template: SMCFanKey.minimum)
-        let maximum = readFanFloat(index, template: SMCFanKey.maximum)
-
-        let modeKey = SMCFanKey.key(modeKeyTemplate, fan: index)
-        let modeResult = smc.readKey(modeKey)
-        let modeValue = modeResult.success && !modeResult.bytes.isEmpty ? modeResult.bytes[0] : 0
-        let mode: String
-        switch modeValue {
-        case 0: mode = "auto"
-        case 1: mode = "manual"
-        case 3: mode = "system"
-        default: mode = "unknown(\(modeValue))"
-        }
+        let limits = fanLimits(index)
 
         return FanInfo(
             index: index,
             actualRPM: actual,
             targetRPM: target,
-            minRPM: minimum,
-            maxRPM: maximum,
-            mode: mode
+            minRPM: limits.min,
+            maxRPM: limits.max,
+            mode: readMode(index)
         )
+    }
+
+    /// Per-fan min/max RPM are firmware constants — read once, then cached.
+    /// Only cached once a valid maximum (> 0) is seen, so a transient zero read
+    /// at startup isn't latched.
+    private func fanLimits(_ index: Int) -> (min: Float, max: Float) {
+        if let cached = cachedLimits[index] { return cached }
+        let minimum = readFanFloat(index, template: SMCFanKey.minimum)
+        let maximum = readFanFloat(index, template: SMCFanKey.maximum)
+        if maximum > 0 { cachedLimits[index] = (minimum, maximum) }
+        return (minimum, maximum)
+    }
+
+    private func readMode(_ index: Int) -> String {
+        let modeResult = smc.readKey(SMCFanKey.key(modeKeyTemplate, fan: index))
+        let modeValue = modeResult.success && !modeResult.bytes.isEmpty ? modeResult.bytes[0] : 0
+        switch modeValue {
+        case 0: return "auto"
+        case 1: return "manual"
+        case 3: return "system"
+        default: return "unknown(\(modeValue))"
+        }
+    }
+
+    /// Min/max RPM of the primary fan (fan 0), cached. Falls back to typical
+    /// Apple Silicon values when no fan is present or limits read as zero.
+    public func primaryFanLimits() -> (minRPM: Float, maxRPM: Float) {
+        guard let count = try? fanCount(), count > 0 else { return (2317, 7826) }
+        let limits = fanLimits(0)
+        return (limits.min > 0 ? limits.min : 2317, limits.max > 0 ? limits.max : 7826)
     }
 
     // MARK: - Unlock
@@ -321,61 +355,92 @@ public final class FanControl {
             ))
         }
 
-        // Probe temperature keys across all known Apple Silicon generations.
-        // Keys that don't exist on a given machine are skipped automatically.
-        // Labels use the raw SMC key name — no assumptions about what a key
-        // means on hardware we haven't verified.
+        // Read every live sensor (the subset present on this machine). Labels
+        // use the raw SMC key name — no assumptions about what a key means on
+        // hardware we haven't verified.
         var temps: [String: Float] = [:]
-
-        // All known CPU/GPU/memory/misc thermal keys (flt type, 4 bytes)
-        let fltKeys: [String] = [
-            // CPU — aggregate (M5 Max verified)
-            "TCDX", "TCHP", "TCMb",
-            // CPU — per-core (Tp prefix, present across M1-M5 with varying mappings)
-            "Tp01", "Tp02", "Tp03", "Tp04", "Tp05", "Tp06", "Tp07", "Tp08",
-            "Tp09", "Tp0A", "Tp0B", "Tp0C", "Tp0D", "Tp0F", "Tp0G", "Tp0H",
-            "Tp0J", "Tp0L", "Tp0P", "Tp0S", "Tp0T", "Tp0W", "Tp0X", "Tp0b",
-            // GPU (flt type — M1 through M4)
-            "Tg05", "Tg0D", "Tg0L", "Tg0T", "Tg0f", "Tg0j",
-            // Memory
-            "Tm02", "Tm06", "Tm08", "Tm09",
-            "TRDX", "TMVR",
-            // Power delivery
-            "TPDX",
-            // SSD
-            "TH0x", "TH0A", "TH0B",
-            // Ambient
-            "TAOL", "TA0P",
-            // Proximity
-            "TS0P",
-            // Battery
-            "TB0T",
-        ]
-
-        for key in fltKeys {
-            let result = smc.readKey(key)
-            if result.success && result.size == 4 {
-                let temp = smcBytesToFloat(result.bytes, size: result.size)
-                if temp > 0 && temp < 150 {
-                    temps[key] = (temp * 10).rounded() / 10
-                }
-            }
-        }
-
-        // ioft type (16.16 fixed-point, 8 bytes) — GPU temps on M5 Max
-        let ioftKeys = ["TG0B", "TG0H", "TG0V"]
-
-        for key in ioftKeys {
-            let result = smc.readKey(key)
-            if result.success && result.size == 8 {
-                let temp = ioftBytesToFloat(result.bytes)
-                if temp > 0 && temp < 150 {
-                    temps[key] = (temp * 10).rounded() / 10
-                }
+        for liveKey in liveTemperatureKeys() {
+            if let temp = readTemp(liveKey) {
+                temps[liveKey.key] = temp
             }
         }
 
         return ThermalStatus(fans: fans, temperatures: temps)
+    }
+
+    // MARK: - Temperatures
+
+    /// Which subsystem a temperature key reports — used to keep the hot control
+    /// read down to just the sensors the controller and 95°C override consume.
+    private enum TempGroup { case cpu, gpu, other }
+    private struct LiveTempKey { let key: String; let isIoft: Bool; let group: TempGroup }
+    private struct TempCandidate { let key: String; let isIoft: Bool; let group: TempGroup }
+
+    /// All known thermal keys across M1–M5. Probed once to find the live subset.
+    /// Grouping mirrors the prefixes the monitor uses: CPU = TC/Tp, GPU = TG/Tg.
+    private static let tempCandidates: [TempCandidate] = {
+        func flt(_ keys: [String], _ group: TempGroup) -> [TempCandidate] {
+            keys.map { TempCandidate(key: $0, isIoft: false, group: group) }
+        }
+        var c: [TempCandidate] = []
+        // CPU — aggregate (M5 Max) + per-core (Tp, M1–M5)
+        c += flt(["TCDX", "TCHP", "TCMb",
+                  "Tp01", "Tp02", "Tp03", "Tp04", "Tp05", "Tp06", "Tp07", "Tp08",
+                  "Tp09", "Tp0A", "Tp0B", "Tp0C", "Tp0D", "Tp0F", "Tp0G", "Tp0H",
+                  "Tp0J", "Tp0L", "Tp0P", "Tp0S", "Tp0T", "Tp0W", "Tp0X", "Tp0b"], .cpu)
+        // GPU — flt (M1–M4)
+        c += flt(["Tg05", "Tg0D", "Tg0L", "Tg0T", "Tg0f", "Tg0j"], .gpu)
+        // Memory / power / SSD / ambient / proximity / battery — display only
+        c += flt(["Tm02", "Tm06", "Tm08", "Tm09", "TRDX", "TMVR", "TPDX",
+                  "TH0x", "TH0A", "TH0B", "TAOL", "TA0P", "TS0P", "TB0T"], .other)
+        // GPU — ioft 16.16 fixed-point, 8 bytes (M5 Max)
+        c += ["TG0B", "TG0H", "TG0V"].map { TempCandidate(key: $0, isIoft: true, group: .gpu) }
+        return c
+    }()
+
+    /// The temperature keys actually present on this machine. Probed once (a
+    /// non-empty result is cached); absent keys are never read again, so the
+    /// hot path stops paying IOKit calls for other generations' sensors.
+    private func liveTemperatureKeys() -> [LiveTempKey] {
+        if let cached = liveTempKeys, !cached.isEmpty { return cached }
+        var live: [LiveTempKey] = []
+        for cand in Self.tempCandidates {
+            let result = smc.readKey(cand.key)
+            let present = cand.isIoft ? (result.success && result.size == 8)
+                                      : (result.success && result.size == 4)
+            if present {
+                live.append(LiveTempKey(key: cand.key, isIoft: cand.isIoft, group: cand.group))
+            }
+        }
+        if !live.isEmpty { liveTempKeys = live }
+        return live
+    }
+
+    private func readTemp(_ liveKey: LiveTempKey) -> Float? {
+        let result = smc.readKey(liveKey.key)
+        guard result.success else { return nil }
+        let temp = liveKey.isIoft
+            ? ioftBytesToFloat(result.bytes)
+            : smcBytesToFloat(result.bytes, size: result.size)
+        guard temp > 0 && temp < 150 else { return nil }
+        return (temp * 10).rounded() / 10
+    }
+
+    /// Cheap read for the control loop: peak CPU and GPU temperature only.
+    /// Skips the ~14 display-only sensors (RAM/SSD/ambient/…) and all fan reads.
+    /// Returns nil when no CPU/GPU sensor could be read (treat as a failed tick).
+    public func controlTemps() -> (cpu: Float, gpu: Float)? {
+        let keys = liveTemperatureKeys()
+        guard !keys.isEmpty else { return nil }
+        var cpu: Float = 0
+        var gpu: Float = 0
+        var read = false
+        for liveKey in keys where liveKey.group != .other {
+            guard let temp = readTemp(liveKey) else { continue }
+            read = true
+            if liveKey.group == .cpu { cpu = max(cpu, temp) } else { gpu = max(gpu, temp) }
+        }
+        return read ? (cpu, gpu) : nil
     }
 
     // MARK: - Discover

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -139,6 +139,13 @@ public final class FanControl {
     /// On M1-M4: writes Ftst=1, then polls until mode write succeeds.
     /// On M5+: Ftst doesn't exist, attempts direct mode write.
     private func unlockFans(count: Int) throws {
+        // Fast path: if every fan is already in manual mode the unlock happened
+        // on an earlier command — skip the Ftst write + 0.5s sleep + poll loop.
+        // (Ftst/mode stay set until resetAuto, so thermalmonitord stays off.)
+        if count > 0 && (0..<count).allSatisfy({ isManualMode($0) }) {
+            return
+        }
+
         if hasFtst {
             // M1-M4 path: Ftst unlock suppresses thermalmonitord
             guard smc.writeKey(SMCFanKey.forceTest, bytes: [1]) else {
@@ -151,6 +158,7 @@ public final class FanControl {
 
         // Set each fan to manual mode
         for i in 0..<count {
+            if isManualMode(i) { continue }   // already manual — skip the poll loop
             let modeKey = SMCFanKey.key(modeKeyTemplate, fan: i)
             let deadline = Date().addingTimeInterval(10.0)
             var success = false
@@ -413,6 +421,13 @@ public final class FanControl {
         let result = smc.readKey(key)
         guard result.success else { return 0 }
         return smcBytesToFloat(result.bytes, size: result.size)
+    }
+
+    /// True if the fan is currently in manual mode (mode key == 1).
+    private func isManualMode(_ index: Int) -> Bool {
+        let modeKey = SMCFanKey.key(modeKeyTemplate, fan: index)
+        let result = smc.readKey(modeKey)
+        return result.success && !result.bytes.isEmpty && result.bytes[0] == 1
     }
 
     private func log(_ message: String) {

--- a/Sources/ThermalForgeCore/SMCConnection.swift
+++ b/Sources/ThermalForgeCore/SMCConnection.swift
@@ -69,6 +69,18 @@ struct SMCParamStruct {
     )
 }
 
+// MARK: - SMC Reading
+
+/// The subset of SMC operations FanControl depends on. Abstracted so tests can
+/// inject a fake key table instead of touching real hardware.
+public protocol SMCReading: AnyObject {
+    func readKey(_ key: String) -> (success: Bool, bytes: [UInt8], size: UInt32)
+    func writeKey(_ key: String, bytes: [UInt8]) -> Bool
+    func getKeyInfo(_ key: String) -> (size: UInt32, type: String)?
+    func getKeyCount() -> UInt32
+    func getKeyAtIndex(_ index: UInt32) -> String?
+}
+
 // MARK: - SMC Connection
 
 /// Direct IOKit interface to the System Management Controller.
@@ -76,6 +88,22 @@ struct SMCParamStruct {
 public final class SMCConnection {
 
     private let connection: io_connect_t
+
+    /// A key's data size is fixed by firmware, so cache it to skip the
+    /// `readKeyInfo` IOKit round trip on repeat reads/writes. Only present keys
+    /// are cached; absence is never cached, so a transiently-failed read of a
+    /// real sensor is always retried (the 95°C override must keep seeing it).
+    private let cacheLock = NSLock()
+    private var sizeCache: [UInt32: UInt32] = [:]
+
+    private func cachedSize(_ code: UInt32) -> UInt32? {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        return sizeCache[code]
+    }
+
+    private func setCachedSize(_ code: UInt32, _ size: UInt32) {
+        cacheLock.lock(); sizeCache[code] = size; cacheLock.unlock()
+    }
 
     public init?() {
         var iterator: io_iterator_t = 0
@@ -110,16 +138,23 @@ public final class SMCConnection {
     public func readKey(_ key: String) -> (success: Bool, bytes: [UInt8], size: UInt32) {
         var input = SMCParamStruct()
         var output = SMCParamStruct()
+        let code = fourCharCode(key)
+        input.key = code
 
-        // Get key info (data size)
-        input.key = fourCharCode(key)
-        input.data8 = SMCCommand.readKeyInfo.rawValue
-        guard callSMC(&input, &output) == kIOReturnSuccess else {
-            return (false, [], 0)
+        // Resolve data size — from cache if known, else one readKeyInfo call.
+        let dataSize: UInt32
+        if let cached = cachedSize(code) {
+            dataSize = cached
+        } else {
+            input.data8 = SMCCommand.readKeyInfo.rawValue
+            guard callSMC(&input, &output) == kIOReturnSuccess else {
+                return (false, [], 0)
+            }
+            let size = output.keyInfo.dataSize
+            guard size > 0 else { return (false, [], 0) }
+            setCachedSize(code, size)
+            dataSize = size
         }
-
-        let dataSize = output.keyInfo.dataSize
-        guard dataSize > 0 else { return (false, [], 0) }
 
         // Read value
         input.keyInfo.dataSize = dataSize
@@ -136,17 +171,25 @@ public final class SMCConnection {
     public func writeKey(_ key: String, bytes: [UInt8]) -> Bool {
         var input = SMCParamStruct()
         var output = SMCParamStruct()
+        let code = fourCharCode(key)
+        input.key = code
 
-        // Get key info first
-        input.key = fourCharCode(key)
-        input.data8 = SMCCommand.readKeyInfo.rawValue
-        guard callSMC(&input, &output) == kIOReturnSuccess else {
-            return false
+        // Resolve data size — from cache if known, else one readKeyInfo call.
+        let dataSize: UInt32
+        if let cached = cachedSize(code) {
+            dataSize = cached
+        } else {
+            input.data8 = SMCCommand.readKeyInfo.rawValue
+            guard callSMC(&input, &output) == kIOReturnSuccess else {
+                return false
+            }
+            dataSize = output.keyInfo.dataSize
+            if dataSize > 0 { setCachedSize(code, dataSize) }
         }
 
         // Write value
         input.data8 = SMCCommand.writeBytes.rawValue
-        input.keyInfo.dataSize = output.keyInfo.dataSize
+        input.keyInfo.dataSize = dataSize
         input.bytes = arrayToTuple(bytes)
 
         guard callSMC(&input, &output) == kIOReturnSuccess else {
@@ -242,6 +285,9 @@ public final class SMCConnection {
         )
     }
 }
+
+// SMCConnection's public methods already match SMCReading.
+extension SMCConnection: SMCReading {}
 
 // Type alias for the 32-byte tuple used in SMCParamStruct
 extension SMCParamStruct {

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -216,16 +216,24 @@ public final class ThermalMonitor {
     // MARK: - Polling
 
     private func tick() {
-        // Cheap control read every tick — only the CPU/GPU sensors the control
-        // loop and the 95°C safety override actually consume.
-        guard let temps = fanControl.controlTemps() else { return }
-        let maxTemp = max(temps.cpu, temps.gpu)
-
-        // The full sensor snapshot (all temps + fan actual/target/mode) is only
-        // consumed by the UI (500ms) and the monitor tick (2s, a multiple of the
-        // UI cadence). Build it on the UI cadence and reuse it for both.
+        // Build the full sensor snapshot only on the UI/monitor cadence (the UI
+        // and 2s monitor tick consume it). On those ticks, derive the control
+        // peak from it instead of re-reading the CPU/GPU sensors; on the other
+        // (control-only) ticks do the cheap CPU/GPU-only read.
         let status = tickCounter % uiUpdateCadence == 0 ? try? fanControl.status() : nil
-        if let status { latestStatus = status }
+        let maxTemp: Float
+        if let status {
+            latestStatus = status
+            maxTemp = status.temperatures
+                .filter { key, _ in
+                    key.hasPrefix("TC") || key.hasPrefix("Tp") || key.hasPrefix("TG") || key.hasPrefix("Tg")
+                }
+                .values.max() ?? 0
+        } else if let temps = fanControl.controlTemps() {
+            maxTemp = max(temps.cpu, temps.gpu)
+        } else {
+            return
+        }
 
         // Monitor cadence: process capture + anomaly detection (every 2 seconds)
         if tickCounter % monitorCadence == 0, let status {

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -44,7 +44,7 @@ public final class ThermalMonitor {
     /// Thermal tick interval in seconds. Fan control runs at this rate.
     /// Set from `start(interval:)` so the ramp / sustained-trigger math (which
     /// divides by it) always matches the real timer rate.
-    private var tickInterval: Float = 0.25
+    private var tickInterval: Float = 1.0
 
     /// Process capture + anomaly detection run every ~2 seconds, regardless of
     /// the tick rate. Derived from tickInterval so the wall-clock cadence holds.
@@ -126,7 +126,7 @@ public final class ThermalMonitor {
 
     // MARK: - Lifecycle
 
-    public func start(interval: TimeInterval = 0.25) {
+    public func start(interval: TimeInterval = 1.0) {
         stop()
 
         activeInterval = Float(interval)

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -52,6 +52,10 @@ public final class ThermalMonitor {
     /// At 100ms thermal tick, 5 × 0.1s = 500ms — smooth UI without excessive redraws.
     private static let uiUpdateCadence = 5
 
+    /// Below this peak temperature the rolling process buffer isn't worth its
+    /// sysctl sweep — skip process capture at idle. (°C)
+    private static let processCaptureFloor: Float = 50.0
+
     private var tickCounter = 0
 
     // MARK: - Fan State
@@ -148,22 +152,23 @@ public final class ThermalMonitor {
     // MARK: - Polling
 
     private func tick() {
-        guard let status = try? fanControl.status() else { return }
-        latestStatus = status
+        // Cheap control read every tick — only the CPU/GPU sensors the control
+        // loop and the 95°C safety override actually consume.
+        guard let temps = fanControl.controlTemps() else { return }
+        let maxTemp = max(temps.cpu, temps.gpu)
 
-        // Extract peak temperatures
-        // CPU: aggregate keys (M5) + per-core keys (M1-M4)
-        let cpuTemp = peakTemp(status, prefixes: ["TC", "Tp"])
-        // GPU: ioft keys (M5) + flt keys (M1-M4)
-        let gpuTemp = peakTemp(status, prefixes: ["TG", "Tg"])
-        let maxTemp = max(cpuTemp, gpuTemp)
+        // The full sensor snapshot (all temps + fan actual/target/mode) is only
+        // consumed by the UI (500ms) and the monitor tick (2s, a multiple of the
+        // UI cadence). Build it on the UI cadence and reuse it for both.
+        let status = tickCounter % Self.uiUpdateCadence == 0 ? try? fanControl.status() : nil
+        if let status { latestStatus = status }
 
         // Monitor cadence: process capture + anomaly detection (every 2 seconds)
-        if tickCounter % Self.monitorCadence == 0 {
+        if tickCounter % Self.monitorCadence == 0, let status {
             monitorTick(status: status, maxTemp: maxTemp)
         }
 
-        // Safety override: any sensor > 95°C
+        // Safety override: any CPU/GPU sensor > 95°C
         if maxTemp >= FanProfile.safetyTempThreshold {
             if state != .safetyOverride {
                 applyCommand(.setMax)
@@ -172,9 +177,7 @@ public final class ThermalMonitor {
                 lastAppliedRPMPercent = 1.0
                 TFLogger.shared.safety("Override triggered: \(String(format: "%.1f", maxTemp))°C — fans maxed")
             }
-            if tickCounter % Self.uiUpdateCadence == 0 {
-                onUpdate?(status, activeProfile, state)
-            }
+            if let status { onUpdate?(status, activeProfile, state) }
             tickCounter += 1
             return
         }
@@ -195,17 +198,16 @@ public final class ThermalMonitor {
             sustainedAboveCount = 0
         }
 
-        // Profile-specific logic
+        // Profile-specific logic — fan min/max are firmware-static (cached).
+        let limits = fanControl.primaryFanLimits()
         if activeProfile.id == "smart" {
-            tickSmart(status: status, peakTemp: maxTemp)
+            tickSmart(peakTemp: maxTemp, minRPM: limits.minRPM, maxRPM: limits.maxRPM)
         } else {
-            tickCurve(status: status, peakTemp: maxTemp)
+            tickCurve(peakTemp: maxTemp, minRPM: limits.minRPM, maxRPM: limits.maxRPM)
         }
 
         // UI update at slower cadence (every 500ms)
-        if tickCounter % Self.uiUpdateCadence == 0 {
-            onUpdate?(status, activeProfile, state)
-        }
+        if let status { onUpdate?(status, activeProfile, state) }
 
         tickCounter += 1
     }
@@ -215,11 +217,18 @@ public final class ThermalMonitor {
     /// Heavy operations: process capture + anomaly detection.
     /// Runs at 2-second intervals to avoid sysctl overhead at 100ms.
     private func monitorTick(status: ThermalStatus, maxTemp: Float) {
-        // Rolling process buffer — always capturing, like a security camera
-        let currentProcs = captureTopProcesses()
-        let ts = isoFormatter.string(from: Date())
-        processBuffer.append((timestamp: ts, processes: currentProcs))
-        if processBuffer.count > 15 { processBuffer.removeFirst() }
+        // Rolling process buffer — captures what was running BEFORE a spike, but
+        // only while the machine is warm enough for one to matter. At true idle
+        // the sysctl(KERN_PROC_ALL) sweep is pure overhead, so skip it and drop
+        // any stale snapshots. Anomaly detection below still runs every cycle.
+        if maxTemp >= Self.processCaptureFloor {
+            let currentProcs = captureTopProcesses()
+            let ts = isoFormatter.string(from: Date())
+            processBuffer.append((timestamp: ts, processes: currentProcs))
+            if processBuffer.count > 15 { processBuffer.removeFirst() }
+        } else if !processBuffer.isEmpty {
+            processBuffer.removeAll()
+        }
 
         // Anomaly detection: two tiers
         // Tier 1: instant spike — >5°C between consecutive readings (2 seconds)
@@ -284,15 +293,13 @@ public final class ThermalMonitor {
     /// All profiles share the same off threshold — 50°C matches Apple's observed stop range
     private static let smartStopTemp: Float = 50.0
 
-    private func tickSmart(status: ThermalStatus, peakTemp: Float) {
+    private func tickSmart(peakTemp: Float, minRPM: Float, maxRPM: Float) {
         // Sample temperature history at monitor cadence (2s) for stable rate-of-change
         if tickCounter % Self.monitorCadence == 0 {
             tempHistory.append(peakTemp)
             if tempHistory.count > 4 { tempHistory.removeFirst() }
         }
 
-        let maxRPM = status.fans.first.map { Float($0.maxRPM) } ?? 7826
-        let minRPM = status.fans.first.map { Float($0.minRPM) } ?? 2317
         let minPct = minRPM / maxRPM
 
         // Below stop threshold and fans running: turn off (with hysteresis)
@@ -397,10 +404,8 @@ public final class ThermalMonitor {
 
     // MARK: - Curve-Based Profiles
 
-    private func tickCurve(status: ThermalStatus, peakTemp: Float) {
+    private func tickCurve(peakTemp: Float, minRPM: Float, maxRPM: Float) {
         let curve = activeProfile.curve
-        let maxRPM = status.fans.first.map { Float($0.maxRPM) } ?? 7826
-        let minRPM = status.fans.first.map { Float($0.minRPM) } ?? 2317
 
         // Hands-off profiles (Silent): don't control fans, just monitor
         if curve.handsOff {
@@ -513,12 +518,6 @@ public final class ThermalMonitor {
     }
 
     // MARK: - Helpers
-
-    private func peakTemp(_ status: ThermalStatus, prefixes: [String]) -> Float {
-        status.temperatures
-            .filter { key, _ in prefixes.contains(where: { key.hasPrefix($0) }) }
-            .values.max() ?? 0
-    }
 
     private func applyCommand(_ command: FanCommand) {
         do {

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -42,15 +42,17 @@ public final class ThermalMonitor {
     // MARK: - Tick Timing
 
     /// Thermal tick interval in seconds. Fan control runs at this rate.
-    private let tickInterval: Float
+    /// Set from `start(interval:)` so the ramp / sustained-trigger math (which
+    /// divides by it) always matches the real timer rate.
+    private var tickInterval: Float = 0.25
 
-    /// Monitor cadence: process capture + anomaly detection every N thermal ticks.
-    /// At 100ms thermal tick, 20 × 0.1s = 2 seconds.
-    private static let monitorCadence = 20
+    /// Process capture + anomaly detection run every ~2 seconds, regardless of
+    /// the tick rate. Derived from tickInterval so the wall-clock cadence holds.
+    private var monitorCadence: Int { max(1, Int((2.0 / tickInterval).rounded())) }
 
-    /// UI update cadence: onUpdate fires every N thermal ticks.
-    /// At 100ms thermal tick, 5 × 0.1s = 500ms — smooth UI without excessive redraws.
-    private static let uiUpdateCadence = 5
+    /// onUpdate / full-status build run every ~500ms. monitorCadence is always
+    /// a multiple of this (2.0 / 0.5 == 4), so a full status exists on monitor ticks.
+    private var uiUpdateCadence: Int { max(1, Int((0.5 / tickInterval).rounded())) }
 
     /// Below this peak temperature the rolling process buffer isn't worth its
     /// sysctl sweep — skip process capture at idle. (°C)
@@ -102,16 +104,19 @@ public final class ThermalMonitor {
     public init(fanControl: FanControl, profile: FanProfile = .silent) {
         self.fanControl = fanControl
         self.activeProfile = profile
-        self.tickInterval = 0.1
     }
 
     // MARK: - Lifecycle
 
-    public func start(interval: TimeInterval = 0.1) {
+    public func start(interval: TimeInterval = 0.25) {
         stop()
 
+        tickInterval = Float(interval)
+
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now(), repeating: interval)
+        // Leeway lets the OS coalesce timer wakeups with other work — a big idle
+        // CPU win for a low-frequency poll, and ±20% is invisible to fan control.
+        timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(Int(interval * 200)))
         timer.setEventHandler { [weak self] in
             self?.tick()
         }
@@ -160,11 +165,11 @@ public final class ThermalMonitor {
         // The full sensor snapshot (all temps + fan actual/target/mode) is only
         // consumed by the UI (500ms) and the monitor tick (2s, a multiple of the
         // UI cadence). Build it on the UI cadence and reuse it for both.
-        let status = tickCounter % Self.uiUpdateCadence == 0 ? try? fanControl.status() : nil
+        let status = tickCounter % uiUpdateCadence == 0 ? try? fanControl.status() : nil
         if let status { latestStatus = status }
 
         // Monitor cadence: process capture + anomaly detection (every 2 seconds)
-        if tickCounter % Self.monitorCadence == 0, let status {
+        if tickCounter % monitorCadence == 0, let status {
             monitorTick(status: status, maxTemp: maxTemp)
         }
 
@@ -295,7 +300,7 @@ public final class ThermalMonitor {
 
     private func tickSmart(peakTemp: Float, minRPM: Float, maxRPM: Float) {
         // Sample temperature history at monitor cadence (2s) for stable rate-of-change
-        if tickCounter % Self.monitorCadence == 0 {
+        if tickCounter % monitorCadence == 0 {
             tempHistory.append(peakTemp)
             if tempHistory.count > 4 { tempHistory.removeFirst() }
         }
@@ -398,7 +403,7 @@ public final class ThermalMonitor {
         let oldest = tempHistory.first!
         let newest = tempHistory.last!
         // tempHistory sampled at monitor cadence (2s intervals)
-        let seconds = Float(tempHistory.count - 1) * Float(Self.monitorCadence) * tickInterval
+        let seconds = Float(tempHistory.count - 1) * Float(monitorCadence) * tickInterval
         return (newest - oldest) / seconds
     }
 

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -165,19 +165,16 @@ public final class ThermalMonitor {
     /// Adjust the poll rate to match thermal activity. Fast while warm/active so
     /// fan control and the 95°C override stay responsive; slow while cool & idle
     /// to keep idle CPU near zero. Reschedules the timer only on a real change.
-    private func applyCadence(maxTemp: Float) {
-        // Busy = controlling fans, mid-event, above this profile's start temp
-        // (sustainedAboveCount > 0), or near the safety ceiling. Anything else is
-        // genuinely idle — even at a 50–60°C Apple-Silicon resting temperature.
-        // sustainedAboveCount tracks crossing the profile's startTemp, but a
-        // handsOff profile (Silent) never acts on it — Apple Silicon idles at
-        // 55–60°C, which is at/above Silent's 55°C start, so counting it here
-        // would wrongly pin Silent to fast polling at idle. For handsOff, only
-        // the 85°C safety watch keeps us fast.
-        let approachingEngagement = !activeProfile.curve.handsOff && sustainedAboveCount > 0
-        let busy = fansCurrentlyRunning
-            || state != .idle
-            || approachingEngagement
+    private func applyCadence(maxTemp: Float, fanChanged: Bool) {
+        // Fast polling is only useful when something is *moving*: the fan speed
+        // just changed (ramping), we're counting toward turning fans on, or
+        // we're near the safety ceiling. Fans merely running at a STEADY speed
+        // doesn't need 4–10 Hz — so a warm idle on Performance (fans holding at
+        // minimum at ~56°C) relaxes to the slow rate instead of polling fast.
+        let engaging = !activeProfile.curve.handsOff && !fansCurrentlyRunning && sustainedAboveCount > 0
+        let busy = fanChanged
+            || engaging
+            || state == .safetyOverride
             || maxTemp >= Self.safetyWatchTemp
 
         if busy {
@@ -186,6 +183,8 @@ public final class ThermalMonitor {
             consecutiveIdleTicks += 1
         }
 
+        // handsOff profiles never adjust fans → slowest idle rate; fan-controlling
+        // profiles holding steady use the medium rate so they still catch a rise.
         let idleRate = activeProfile.curve.handsOff ? Self.handsOffIdleInterval : Self.idleInterval
         let wantFast = busy || consecutiveIdleTicks < Self.idleConfirmTicks
         let desired = wantFast ? activeInterval : max(idleRate, activeInterval)
@@ -256,7 +255,7 @@ public final class ThermalMonitor {
                 TFLogger.shared.safety("Override triggered: \(String(format: "%.1f", maxTemp))°C — fans maxed")
             }
             if let status { onUpdate?(status, activeProfile, state) }
-            applyCadence(maxTemp: maxTemp)
+            applyCadence(maxTemp: maxTemp, fanChanged: true)
             tickCounter += 1
             return
         }
@@ -278,17 +277,22 @@ public final class ThermalMonitor {
         }
 
         // Profile-specific logic — fan min/max are firmware-static (cached).
+        // Track whether the applied fan speed actually moved this tick: that's
+        // the signal for fast polling (ramping) vs relaxing (holding steady).
+        let appliedBefore = lastAppliedRPMPercent
+        let runningBefore = fansCurrentlyRunning
         let limits = fanControl.primaryFanLimits()
         if activeProfile.id == "smart" {
             tickSmart(peakTemp: maxTemp, minRPM: limits.minRPM, maxRPM: limits.maxRPM)
         } else {
             tickCurve(peakTemp: maxTemp, minRPM: limits.minRPM, maxRPM: limits.maxRPM)
         }
+        let fanChanged = lastAppliedRPMPercent != appliedBefore || fansCurrentlyRunning != runningBefore
 
         // UI update at slower cadence (every 500ms)
         if let status { onUpdate?(status, activeProfile, state) }
 
-        applyCadence(maxTemp: maxTemp)
+        applyCadence(maxTemp: maxTemp, fanChanged: fanChanged)
         tickCounter += 1
     }
 

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -164,9 +164,15 @@ public final class ThermalMonitor {
         // Busy = controlling fans, mid-event, above this profile's start temp
         // (sustainedAboveCount > 0), or near the safety ceiling. Anything else is
         // genuinely idle — even at a 50–60°C Apple-Silicon resting temperature.
+        // sustainedAboveCount tracks crossing the profile's startTemp, but a
+        // handsOff profile (Silent) never acts on it — Apple Silicon idles at
+        // 55–60°C, which is at/above Silent's 55°C start, so counting it here
+        // would wrongly pin Silent to fast polling at idle. For handsOff, only
+        // the 85°C safety watch keeps us fast.
+        let approachingEngagement = !activeProfile.curve.handsOff && sustainedAboveCount > 0
         let busy = fansCurrentlyRunning
             || state != .idle
-            || sustainedAboveCount > 0
+            || approachingEngagement
             || maxTemp >= Self.safetyWatchTemp
 
         if busy {

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -62,15 +62,19 @@ public final class ThermalMonitor {
 
     /// Fast poll rate, from `start(interval:)`. Used while warm or active.
     private var activeInterval: Float = 0.25
-    /// Slow poll rate while cool & idle. Idle CPU is dominated by per-key SMC
-    /// reads (~150µs each), so fewer ticks ≈ proportionally less idle CPU.
+    /// Slow poll rate while idle. Idle CPU is dominated by per-key SMC reads
+    /// (~150µs each), so fewer ticks ≈ proportionally less idle CPU.
     private static let idleInterval: Float = 2.0
-    /// Switch to fast polling at/above this temp; fall back to slow below the
-    /// exit threshold (hysteresis avoids flapping). Nothing engages below the
-    /// lowest profile startTemp (53°C), so slow polling here is safe.
-    private static let cadenceWarmEnter: Float = 48.0
-    private static let cadenceWarmExit: Float = 44.0
-    private var fastCadence = true
+    /// Stay fast at/above this temp regardless of profile, so the 95°C safety
+    /// override reacts promptly. Apple Silicon idles ~45–60°C — overlapping the
+    /// profile start temps — so a plain temp threshold can never relax. The real
+    /// "can slow down" signal is state-based: fans off, idle, and below this
+    /// profile's start temp (sustainedAboveCount == 0).
+    private static let safetyWatchTemp: Float = 85.0
+    /// Require this many consecutive idle ticks before relaxing, so hovering at a
+    /// start temp doesn't flap the timer. Returns to fast immediately on activity.
+    private static let idleConfirmTicks = 8
+    private var consecutiveIdleTicks = 0
 
     private var tickCounter = 0
 
@@ -127,7 +131,7 @@ public final class ThermalMonitor {
 
         activeInterval = Float(interval)
         tickInterval = activeInterval
-        fastCadence = true
+        consecutiveIdleTicks = 0
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
         scheduleTimer(timer, interval: tickInterval)
@@ -157,13 +161,22 @@ public final class ThermalMonitor {
     /// fan control and the 95°C override stay responsive; slow while cool & idle
     /// to keep idle CPU near zero. Reschedules the timer only on a real change.
     private func applyCadence(maxTemp: Float) {
-        if maxTemp >= Self.cadenceWarmEnter || fansCurrentlyRunning || state != .idle {
-            fastCadence = true
-        } else if maxTemp < Self.cadenceWarmExit {
-            fastCadence = false
+        // Busy = controlling fans, mid-event, above this profile's start temp
+        // (sustainedAboveCount > 0), or near the safety ceiling. Anything else is
+        // genuinely idle — even at a 50–60°C Apple-Silicon resting temperature.
+        let busy = fansCurrentlyRunning
+            || state != .idle
+            || sustainedAboveCount > 0
+            || maxTemp >= Self.safetyWatchTemp
+
+        if busy {
+            consecutiveIdleTicks = 0
+        } else if consecutiveIdleTicks < Self.idleConfirmTicks {
+            consecutiveIdleTicks += 1
         }
 
-        let desired = fastCadence ? activeInterval : max(Self.idleInterval, activeInterval)
+        let wantFast = busy || consecutiveIdleTicks < Self.idleConfirmTicks
+        let desired = wantFast ? activeInterval : max(Self.idleInterval, activeInterval)
         guard desired != tickInterval, let timer else { return }
         tickInterval = desired
         scheduleTimer(timer, interval: desired)

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -62,9 +62,14 @@ public final class ThermalMonitor {
 
     /// Fast poll rate, from `start(interval:)`. Used while warm or active.
     private var activeInterval: Float = 0.25
-    /// Slow poll rate while idle. Idle CPU is dominated by per-key SMC reads
-    /// (~150µs each), so fewer ticks ≈ proportionally less idle CPU.
+    /// Slow poll rate while idle. Idle CPU is dominated by SMC reads, so fewer
+    /// ticks ≈ proportionally less idle CPU.
     private static let idleInterval: Float = 2.0
+    /// Hands-off profiles (Silent) never control fans — Apple's thermald does —
+    /// so we only poll for the menu-bar readout and the 95°C safety backup.
+    /// Both tolerate a much slower idle poll, which is the single biggest idle
+    /// CPU lever for the default profile.
+    private static let handsOffIdleInterval: Float = 5.0
     /// Stay fast at/above this temp regardless of profile, so the 95°C safety
     /// override reacts promptly. Apple Silicon idles ~45–60°C — overlapping the
     /// profile start temps — so a plain temp threshold can never relax. The real
@@ -181,8 +186,9 @@ public final class ThermalMonitor {
             consecutiveIdleTicks += 1
         }
 
+        let idleRate = activeProfile.curve.handsOff ? Self.handsOffIdleInterval : Self.idleInterval
         let wantFast = busy || consecutiveIdleTicks < Self.idleConfirmTicks
-        let desired = wantFast ? activeInterval : max(Self.idleInterval, activeInterval)
+        let desired = wantFast ? activeInterval : max(idleRate, activeInterval)
         guard desired != tickInterval, let timer else { return }
         tickInterval = desired
         scheduleTimer(timer, interval: desired)

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -58,6 +58,20 @@ public final class ThermalMonitor {
     /// sysctl sweep — skip process capture at idle. (°C)
     private static let processCaptureFloor: Float = 50.0
 
+    // MARK: - Adaptive cadence
+
+    /// Fast poll rate, from `start(interval:)`. Used while warm or active.
+    private var activeInterval: Float = 0.25
+    /// Slow poll rate while cool & idle. Idle CPU is dominated by per-key SMC
+    /// reads (~150µs each), so fewer ticks ≈ proportionally less idle CPU.
+    private static let idleInterval: Float = 2.0
+    /// Switch to fast polling at/above this temp; fall back to slow below the
+    /// exit threshold (hysteresis avoids flapping). Nothing engages below the
+    /// lowest profile startTemp (53°C), so slow polling here is safe.
+    private static let cadenceWarmEnter: Float = 48.0
+    private static let cadenceWarmExit: Float = 44.0
+    private var fastCadence = true
+
     private var tickCounter = 0
 
     // MARK: - Fan State
@@ -111,12 +125,12 @@ public final class ThermalMonitor {
     public func start(interval: TimeInterval = 0.25) {
         stop()
 
-        tickInterval = Float(interval)
+        activeInterval = Float(interval)
+        tickInterval = activeInterval
+        fastCadence = true
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        // Leeway lets the OS coalesce timer wakeups with other work — a big idle
-        // CPU win for a low-frequency poll, and ±20% is invisible to fan control.
-        timer.schedule(deadline: .now(), repeating: interval, leeway: .milliseconds(Int(interval * 200)))
+        scheduleTimer(timer, interval: tickInterval)
         timer.setEventHandler { [weak self] in
             self?.tick()
         }
@@ -127,6 +141,32 @@ public final class ThermalMonitor {
     public func stop() {
         timer?.cancel()
         timer = nil
+    }
+
+    /// (Re)schedule the repeating timer. Leeway lets the OS coalesce wakeups —
+    /// a big idle-CPU win for a low-frequency poll; ±20% is invisible to fans.
+    private func scheduleTimer(_ timer: DispatchSourceTimer, interval: Float) {
+        timer.schedule(
+            deadline: .now() + Double(interval),
+            repeating: Double(interval),
+            leeway: .milliseconds(Int(interval * 200))
+        )
+    }
+
+    /// Adjust the poll rate to match thermal activity. Fast while warm/active so
+    /// fan control and the 95°C override stay responsive; slow while cool & idle
+    /// to keep idle CPU near zero. Reschedules the timer only on a real change.
+    private func applyCadence(maxTemp: Float) {
+        if maxTemp >= Self.cadenceWarmEnter || fansCurrentlyRunning || state != .idle {
+            fastCadence = true
+        } else if maxTemp < Self.cadenceWarmExit {
+            fastCadence = false
+        }
+
+        let desired = fastCadence ? activeInterval : max(Self.idleInterval, activeInterval)
+        guard desired != tickInterval, let timer else { return }
+        tickInterval = desired
+        scheduleTimer(timer, interval: desired)
     }
 
     /// Update the active profile.
@@ -183,6 +223,7 @@ public final class ThermalMonitor {
                 TFLogger.shared.safety("Override triggered: \(String(format: "%.1f", maxTemp))°C — fans maxed")
             }
             if let status { onUpdate?(status, activeProfile, state) }
+            applyCadence(maxTemp: maxTemp)
             tickCounter += 1
             return
         }
@@ -214,6 +255,7 @@ public final class ThermalMonitor {
         // UI update at slower cadence (every 500ms)
         if let status { onUpdate?(status, activeProfile, state) }
 
+        applyCadence(maxTemp: maxTemp)
         tickCounter += 1
     }
 

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -33,7 +33,7 @@ public enum MonitorState: Equatable {
 public final class ThermalMonitor {
     private let fanControl: FanControl
     private var timer: DispatchSourceTimer?
-    private let queue = DispatchQueue(label: "com.thermalforge.monitor")
+    private let queue = DispatchQueue(label: "com.thermalforge.monitor", qos: .utility)
 
     public private(set) var activeProfile: FanProfile
     public private(set) var state: MonitorState = .idle

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -208,8 +208,8 @@ struct Watch: ParsableCommand {
     @Option(name: .shortAndLong, help: "Profile: silent, balanced, performance, max")
     var profile: String = "balanced"
 
-    @Option(name: .shortAndLong, help: "Poll interval in seconds (default 0.1 = 100ms)")
-    var interval: Double = 0.1
+    @Option(name: .shortAndLong, help: "Poll interval in seconds (default 0.25 = 250ms)")
+    var interval: Double = 0.25
 
     @Flag(name: .long, help: "Output JSON on each update")
     var json: Bool = false

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -208,8 +208,8 @@ struct Watch: ParsableCommand {
     @Option(name: .shortAndLong, help: "Profile: silent, balanced, performance, max")
     var profile: String = "balanced"
 
-    @Option(name: .shortAndLong, help: "Poll interval in seconds (default 0.25 = 250ms)")
-    var interval: Double = 0.25
+    @Option(name: .shortAndLong, help: "Active poll interval in seconds (default 1.0; relaxes to 2s when idle)")
+    var interval: Double = 1.0
 
     @Flag(name: .long, help: "Output JSON on each update")
     var json: Bool = false

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -514,6 +514,10 @@ struct Install: ParsableCommand {
                 <true/>
                 <key>KeepAlive</key>
                 <true/>
+                <key>ProcessType</key>
+                <string>Adaptive</string>
+                <key>LowPriorityIO</key>
+                <true/>
             </dict>
             </plist>
             """

--- a/Tests/ThermalForgeTests/CommandCoalescerTests.swift
+++ b/Tests/ThermalForgeTests/CommandCoalescerTests.swift
@@ -1,0 +1,109 @@
+//
+//  CommandCoalescerTests.swift
+//  ThermalForge
+//
+//  Unit tests for the fan-command coalescer — the mechanism that stops a
+//  high-frequency ramp from piling up daemon round-trips (the profile-switch
+//  freeze). Verifies: work runs off the caller's thread, a burst collapses to
+//  its most recent command, and spaced-out commands are each delivered.
+//
+
+import Dispatch
+import Foundation
+import Testing
+
+@testable import ThermalForgeCore
+
+@Suite("Command Coalescer")
+struct CommandCoalescerTests {
+
+    @Test("submit never runs the handler on the caller's thread")
+    func submitIsAsynchronous() {
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+
+        let coalescer = CommandCoalescer<Int>(label: "test.async") { _ in
+            entered.signal()
+            release.wait()
+        }
+
+        coalescer.submit(1)
+        // If submit ran the handler inline, we'd be blocked in release.wait()
+        // right now and could never observe `entered`. Reaching here proves the
+        // handler is running on the coalescer's own queue.
+        #expect(entered.wait(timeout: .now() + 2) == .success)
+        release.signal()
+    }
+
+    @Test("A burst collapses to its most recent command")
+    func burstCoalesces() {
+        let handledLock = NSLock()
+        var handled: [Int] = []
+
+        let firstStarted = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let sawLast = DispatchSemaphore(value: 0)
+
+        let coalescer = CommandCoalescer<Int>(label: "test.burst") { cmd in
+            handledLock.lock()
+            handled.append(cmd)
+            handledLock.unlock()
+
+            if cmd == 1 {
+                firstStarted.signal()   // handler(1) is now running...
+                release.wait()          // ...and parked until the burst is queued
+            }
+            if cmd == 99 { sawLast.signal() }
+        }
+
+        coalescer.submit(1)
+        #expect(firstStarted.wait(timeout: .now() + 2) == .success)
+
+        // Queued while the drainer is busy with 1: 2 and 3 get overwritten by 99.
+        coalescer.submit(2)
+        coalescer.submit(3)
+        coalescer.submit(99)
+
+        release.signal()
+        #expect(sawLast.wait(timeout: .now() + 2) == .success)
+
+        handledLock.lock()
+        let result = handled
+        handledLock.unlock()
+        #expect(result == [1, 99], "Expected the burst to collapse to [1, 99], got \(result)")
+    }
+
+    @Test("Commands submitted with the drainer idle are each delivered")
+    func sequentialDeliveryWhenIdle() {
+        let handledLock = NSLock()
+        var handled: [Int] = []
+        let done = DispatchSemaphore(value: 0)
+
+        let coalescer = CommandCoalescer<Int>(label: "test.sequential") { cmd in
+            handledLock.lock()
+            handled.append(cmd)
+            handledLock.unlock()
+            if cmd == 3 { done.signal() }
+        }
+
+        // Each submit waits for the previous to be observed, so the drainer is
+        // idle between them — nothing should be coalesced away.
+        for value in 1...3 {
+            coalescer.submit(value)
+            let deadline = Date().addingTimeInterval(2)
+            while Date() < deadline {
+                handledLock.lock()
+                let seen = handled.contains(value)
+                handledLock.unlock()
+                if seen { break }
+                Thread.sleep(forTimeInterval: 0.005)
+            }
+        }
+
+        #expect(done.wait(timeout: .now() + 2) == .success)
+        handledLock.lock()
+        let result = handled
+        handledLock.unlock()
+        #expect(result == [1, 2, 3])
+    }
+}

--- a/Tests/ThermalForgeTests/DaemonClientTests.swift
+++ b/Tests/ThermalForgeTests/DaemonClientTests.swift
@@ -1,0 +1,176 @@
+//
+//  DaemonClientTests.swift
+//  ThermalForge
+//
+//  Integration tests for DaemonClient against a real Unix-domain socket server.
+//  The freeze fix added a socket timeout so a stuck daemon can never block the
+//  caller forever — `timesOutOnAStuckDaemon` is the regression test for it.
+//
+
+import Darwin
+import Dispatch
+import Foundation
+import Testing
+
+@testable import ThermalForgeCore
+
+/// Minimal in-process Unix-socket server standing in for the privileged daemon.
+/// Either replies with a fixed string or stalls (never replies) to exercise the
+/// client's receive timeout. Records the commands it received.
+final class FakeDaemon: @unchecked Sendable {
+    enum Behavior {
+        case reply(String)
+        case stall
+    }
+
+    let path: String
+    private let listenFD: Int32
+    private let behavior: Behavior
+    private let queue = DispatchQueue(label: "test.fakedaemon")
+    private let lock = NSLock()
+    private var receivedCommands: [String] = []
+    private var stopped = false
+
+    init?(_ behavior: Behavior) {
+        self.behavior = behavior
+        self.path = "/tmp/tf-test-\(UUID().uuidString.prefix(8)).sock"
+
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        self.listenFD = fd
+
+        unlink(path)
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        FakeDaemon.setPath(&addr, path)
+
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bound == 0, listen(fd, 5) == 0 else {
+            close(fd)
+            return nil
+        }
+
+        queue.async { [self] in acceptLoop() }
+    }
+
+    func received() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return receivedCommands
+    }
+
+    func stop() {
+        lock.lock()
+        guard !stopped else { lock.unlock(); return }
+        stopped = true
+        lock.unlock()
+        close(listenFD)
+        unlink(path)
+    }
+
+    deinit { stop() }
+
+    private func acceptLoop() {
+        while true {
+            let clientFD = accept(listenFD, nil, nil)
+            if clientFD < 0 { return }   // listening socket closed → done
+
+            var buffer = [UInt8](repeating: 0, count: 256)
+            let n = read(clientFD, &buffer, buffer.count - 1)
+            if n > 0 {
+                let cmd = String(bytes: buffer[0..<n], encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                lock.lock(); receivedCommands.append(cmd); lock.unlock()
+            }
+
+            switch behavior {
+            case .reply(let response):
+                let bytes = Array((response + "\n").utf8)
+                _ = bytes.withUnsafeBufferPointer { write(clientFD, $0.baseAddress, $0.count) }
+            case .stall:
+                // Hold the connection open without replying so the client's
+                // SO_RCVTIMEO fires. Bounded so the test process doesn't linger.
+                Thread.sleep(forTimeInterval: 3)
+            }
+            close(clientFD)
+        }
+    }
+
+    private static func setPath(_ addr: inout sockaddr_un, _ path: String) {
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dst in
+                _ = strlcpy(dst, path, 104)
+            }
+        }
+    }
+}
+
+@Suite("Daemon Client (integration)")
+struct DaemonClientTests {
+
+    @Test("Round-trips a successful response")
+    func successfulRoundTrip() throws {
+        let daemon = try #require(FakeDaemon(.reply("ok")))
+        defer { daemon.stop() }
+
+        let client = DaemonClient(socketPath: daemon.path, timeoutSeconds: 2)
+        let response = try client.send("status")
+        #expect(response == "ok")
+    }
+
+    @Test("Maps a daemon 'error:' reply to .commandFailed")
+    func surfacesDaemonError() throws {
+        let daemon = try #require(FakeDaemon(.reply("error: boom")))
+        defer { daemon.stop() }
+
+        let client = DaemonClient(socketPath: daemon.path, timeoutSeconds: 2)
+        do {
+            _ = try client.send("max")
+            Issue.record("expected DaemonError.commandFailed")
+        } catch let DaemonError.commandFailed(message) {
+            #expect(message == "boom")
+        }
+    }
+
+    @Test("Times out instead of hanging on a stuck daemon")
+    func timesOutOnAStuckDaemon() throws {
+        let daemon = try #require(FakeDaemon(.stall))
+        defer { daemon.stop() }
+
+        let client = DaemonClient(socketPath: daemon.path, timeoutSeconds: 1)
+        let start = Date()
+        do {
+            _ = try client.send("set 3000")
+            Issue.record("expected DaemonError.timedOut")
+        } catch DaemonError.timedOut {
+            let elapsed = Date().timeIntervalSince(start)
+            // Bounded by the 1s timeout — must not block for the daemon's full stall.
+            #expect(elapsed < 2.5, "send() took \(elapsed)s — timeout did not bound it")
+        }
+    }
+
+    @Test("Throws .notRunning when no daemon is listening")
+    func notRunningWhenNoServer() {
+        let deadPath = "/tmp/tf-absent-\(UUID().uuidString.prefix(8)).sock"
+        let client = DaemonClient(socketPath: deadPath, timeoutSeconds: 1)
+        #expect(throws: DaemonError.self) {
+            _ = try client.send("status")
+        }
+    }
+
+    @Test("execute() encodes FanCommand onto the wire")
+    func executeEncodesCommands() throws {
+        let daemon = try #require(FakeDaemon(.reply("ok")))
+        defer { daemon.stop() }
+
+        let client = DaemonClient(socketPath: daemon.path, timeoutSeconds: 2)
+        try client.execute(.setRPM(1500))
+        try client.execute(.setMax)
+        try client.execute(.resetAuto)
+
+        #expect(daemon.received() == ["set 1500", "max", "auto"])
+    }
+}

--- a/Tests/ThermalForgeTests/FanControlTests.swift
+++ b/Tests/ThermalForgeTests/FanControlTests.swift
@@ -1,0 +1,161 @@
+//
+//  FanControlTests.swift
+//  ThermalForge
+//
+//  Unit tests for the polling optimizations: live-key probing (#3), the cheap
+//  control read that touches only CPU/GPU (#4), and caching of firmware-static
+//  facts — fan count + min/max RPM (#5). Backed by a fake SMC key table so the
+//  tests assert exactly which keys get read, with no real hardware.
+//
+
+import Testing
+
+@testable import ThermalForgeCore
+
+/// In-memory SMC stand-in. Holds a key table and counts every read so tests can
+/// assert that absent / display-only keys aren't re-read on the hot path.
+final class FakeSMC: SMCReading {
+    private struct Entry { var bytes: [UInt8]; var size: UInt32 }
+    private var table: [String: Entry] = [:]
+    private(set) var readCounts: [String: Int] = [:]
+
+    func setFloat(_ key: String, _ value: Float) {
+        table[key] = Entry(bytes: floatToSMCBytes(value), size: 4)
+    }
+
+    func setIoft(_ key: String, _ value: Float) {
+        let raw = UInt32(value * 65536).littleEndian
+        let four = withUnsafeBytes(of: raw) { Array($0) }
+        table[key] = Entry(bytes: four + [0, 0, 0, 0], size: 8)
+    }
+
+    func setByte(_ key: String, _ value: UInt8) {
+        table[key] = Entry(bytes: [value], size: 1)
+    }
+
+    func reads(_ key: String) -> Int { readCounts[key, default: 0] }
+
+    // MARK: SMCReading
+    func readKey(_ key: String) -> (success: Bool, bytes: [UInt8], size: UInt32) {
+        readCounts[key, default: 0] += 1
+        guard let e = table[key] else { return (false, [], 0) }
+        return (true, e.bytes, e.size)
+    }
+    func writeKey(_ key: String, bytes: [UInt8]) -> Bool {
+        if table[key] != nil { table[key]!.bytes = bytes }
+        return true
+    }
+    func getKeyInfo(_ key: String) -> (size: UInt32, type: String)? {
+        table[key].map { ($0.size, "flt ") }
+    }
+    func getKeyCount() -> UInt32 { UInt32(table.count) }
+    func getKeyAtIndex(_ index: UInt32) -> String? { nil }
+}
+
+/// A single-fan machine with a representative temperature key set:
+/// CPU = TCDX/Tp01/Tp09, GPU = Tg05 (flt) + TG0B (ioft), plus display-only
+/// RAM/SSD/ambient sensors. Other candidate keys are deliberately absent.
+private func makeFakeMachine() -> FakeSMC {
+    let smc = FakeSMC()
+    // Fan 0 (manual mode → lowercase template detected)
+    smc.setByte("FNum", 1)
+    smc.setByte("F0md", 1)
+    smc.setFloat("F0Ac", 1500)
+    smc.setFloat("F0Tg", 1500)
+    smc.setFloat("F0Mn", 2317)
+    smc.setFloat("F0Mx", 7826)
+    // CPU
+    smc.setFloat("TCDX", 60.0)
+    smc.setFloat("Tp01", 55.0)
+    smc.setFloat("Tp09", 62.5)
+    // GPU — both flt and ioft paths
+    smc.setFloat("Tg05", 48.0)
+    smc.setIoft("TG0B", 50.0)
+    // Display-only
+    smc.setFloat("Tm02", 40.0)
+    smc.setFloat("TH0A", 45.0)
+    smc.setFloat("TA0P", 30.0)
+    return smc
+}
+
+@Suite("Fan Control polling")
+struct FanControlTests {
+
+    @Test("controlTemps returns the CPU and GPU peaks")
+    func controlTempsPeaks() {
+        let fc = FanControl(smc: makeFakeMachine())
+        let temps = fc.controlTemps()
+        #expect(temps?.cpu == 62.5)   // max(TCDX 60, Tp01 55, Tp09 62.5)
+        #expect(temps?.gpu == 50.0)   // max(Tg05 48, TG0B 50)
+    }
+
+    @Test("control read never touches display-only or absent sensors (#3, #4)")
+    func controlReadStaysOnCpuGpu() {
+        let smc = makeFakeMachine()
+        let fc = FanControl(smc: smc)
+
+        for _ in 0..<3 { _ = fc.controlTemps() }
+
+        // Present CPU/GPU keys: probed once + read on each of the 3 calls.
+        #expect(smc.reads("TCDX") == 4)
+        #expect(smc.reads("TG0B") == 4)
+        // Display-only keys: probed once, then never touched by the control path.
+        #expect(smc.reads("Tm02") == 1)
+        #expect(smc.reads("TH0A") == 1)
+        #expect(smc.reads("TA0P") == 1)
+        // Absent candidate: probed once, never read again.
+        #expect(smc.reads("Tp02") == 1)
+    }
+
+    @Test("Fan count and min/max RPM are read once, not per call (#5)")
+    func staticFanFactsCached() {
+        let smc = makeFakeMachine()
+        let fc = FanControl(smc: smc)
+
+        for _ in 0..<3 { _ = try? fc.status() }
+        _ = fc.primaryFanLimits()
+
+        #expect(smc.reads("FNum") == 1)     // fan count cached after first read
+        #expect(smc.reads("F0Mn") == 1)     // min RPM is firmware-static → cached
+        #expect(smc.reads("F0Mx") == 1)     // max RPM cached
+        #expect(smc.reads("F0Ac") == 3)     // actual RPM still read fresh each status
+    }
+
+    @Test("status reports exactly the live sensors, decoded correctly")
+    func statusReportsLiveSensors() throws {
+        let fc = FanControl(smc: makeFakeMachine())
+        let status = try fc.status()
+        let temps = status.temperatures
+
+        #expect(temps["TCDX"] == 60.0)
+        #expect(temps["Tp09"] == 62.5)
+        #expect(temps["TG0B"] == 50.0)   // ioft 16.16 decode
+        #expect(temps["Tm02"] == 40.0)
+        // Absent candidates never appear.
+        #expect(temps["Tp02"] == nil)
+        #expect(temps["TG0H"] == nil)
+        #expect(status.fans.count == 1)
+        #expect(status.fans.first?.maxRPM == 7826)
+    }
+
+    @Test("controlTemps and status agree on the CPU/GPU peaks")
+    func controlAndStatusAgree() throws {
+        let fc = FanControl(smc: makeFakeMachine())
+        let control = fc.controlTemps()
+        let status = try fc.status()
+
+        let cpu = status.temperatures.filter { k, _ in k.hasPrefix("TC") || k.hasPrefix("Tp") }.values.max()
+        let gpu = status.temperatures.filter { k, _ in k.hasPrefix("TG") || k.hasPrefix("Tg") }.values.max()
+        #expect(control?.cpu == cpu)
+        #expect(control?.gpu == gpu)
+    }
+
+    @Test("controlTemps returns nil when no CPU/GPU sensor is present")
+    func controlTempsNilWithoutSensors() {
+        let smc = FakeSMC()
+        smc.setByte("FNum", 1)
+        smc.setFloat("F0Mx", 7826)   // a fan key, but no temperature keys
+        let fc = FanControl(smc: smc)
+        #expect(fc.controlTemps() == nil)
+    }
+}


### PR DESCRIPTION
## Summary
Two things in one branch (happy to split into separate PRs if you'd prefer):
1. Fix a UI freeze (beachball) when switching to an active fan profile.
2. Cut idle CPU from ~9% to ~0.3% and fix a multi-GB/week daemon memory leak.

`swift build` is clean (zero warnings) and `swift test` passes (38 tests).

## 1. Fix: UI freeze on profile switch
**Symptom:** selecting an active profile (e.g. Performance) froze the app.
**Cause:** fan commands ran on the main actor via a blocking, un-timed-out Unix-socket round-trip to the daemon. During a ramp (~10 cmds/s at the 100 ms tick) they piled up and starved the UI run loop.
**Fix:**
- `PrivilegedExecutor`: send commands on a coalesced background queue (latest-wins), never on the main thread.
- `DaemonClient`: `SO_RCVTIMEO`/`SO_SNDTIMEO` + `DaemonError.timedOut` so a stuck daemon can't hang the caller.
- `FanControl`: skip the unlock (Ftst + 0.5 s sleep + poll loop) when fans are already in manual mode.

## 2. Performance: idle CPU ~9% → ~0.3%
Validated with `powermetrics` (idle wakeups / Energy Impact, not just CPU%).
- **SMC layer:** cache per-key data size (2→1 IOKit call/read), probe the live key set once and skip absent keys, cache static fan limits, and split a cheap CPU/GPU-only control read from the full sensor sweep.
- **Adaptive poll cadence:** 1 s while ramping, 2 s holding steady, 5 s for hands-off Silent; `tickInterval` now tracks the real timer rate (fixes a latent ramp/sustained-trigger desync); dispatch-timer leeway added.
- **Daemon:** wrap the two infinite GCD loops in `autoreleasepool` (fixes a multi-GB-over-days leak); `ProcessType=Adaptive` + `LowPriorityIO` in the launchd plist; handle the heartbeat without `smcLock` and without per-command logging.
- **App/UI:** migrate `AppState` to `@Observable` with publish-on-change; **stop the hidden `MenuBarExtra` panel from re-rendering every tick** (it kept observing per-tick `latestStatus` while not visible — profiling showed this was the dominant idle cost); gate the 5 s heartbeat to fan-controlling profiles; QoS `.utility` on the poll/exec queues.

Result on an M-series Mac (macOS 26), idle, menu closed: app ~0.27% CPU, Energy Impact ~0.1, 0 package-idle wakeups; daemon ~0.1%.

## Notes
- Evaluated reading temps via `IOHIDEventSystemClient` (the macmon approach) but benchmarked it ~13× slower than per-key SMC on this M3/M4-gen chip (~814 µs/sensor × 42 sensors), so it was reverted. macmon's own code also selects SMC over IOHID on M2/M3.

## Tests
Added unit tests (command coalescer; SMC caching / live-key filtering) and integration tests (daemon client incl. the socket timeout). 38 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)