### PR TITLE
Add auto-revert timer to fall back to Default profile

### DIFF
--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -21,10 +21,20 @@ final class AppState: ObservableObject {
     @Published var launchAtLogin: Bool = false {
         didSet { updateLoginItem() }
     }
+    /// Minutes after which a non-default profile auto-reverts to Default.
+    /// 0 == off. Changing it re-arms the timer.
+    @Published var autoRevertMinutes: Int =
+        UserDefaults.standard.integer(forKey: "autoRevertMinutes") {
+        didSet {
+            UserDefaults.standard.set(autoRevertMinutes, forKey: "autoRevertMinutes")
+            armAutoRevert()
+        }
+    }
 
     private var monitor: ThermalMonitor?
     private let executor = PrivilegedExecutor()
     private var heartbeatTimer: Timer?
+    private var autoRevertTimer: Timer?
 
     init() {
         launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -42,6 +52,28 @@ final class AppState: ObservableObject {
 
     deinit {
         heartbeatTimer?.invalidate()
+        autoRevertTimer?.invalidate()
+    }
+
+    // MARK: - Auto-revert
+
+    /// (Re)arm the auto-revert timer. Fires once after `autoRevertMinutes` and
+    /// reverts to Default. No-op when off or already on the default profile.
+    private func armAutoRevert() {
+        autoRevertTimer?.invalidate()
+        autoRevertTimer = nil
+        guard autoRevertMinutes > 0, activeProfile.id != "silent" else { return }
+
+        let minutes = autoRevertMinutes
+        autoRevertTimer = Timer.scheduledTimer(
+            withTimeInterval: TimeInterval(minutes * 60), repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                TFLogger.shared.profile("Auto-revert: \(minutes)min elapsed — reverting to Default")
+                self.resetAuto()
+            }
+        }
     }
 
     // MARK: - Heartbeat
@@ -87,9 +119,12 @@ final class AppState: ObservableObject {
         activeProfile = .smart
         monitor?.switchProfile(.smart)
         TFLogger.shared.profile("Smart activated")
+        armAutoRevert()
     }
 
     func resetAuto() {
+        autoRevertTimer?.invalidate()
+        autoRevertTimer = nil
         do {
             try executor.execute(.resetAuto)
             activeProfile = .silent
@@ -116,6 +151,7 @@ final class AppState: ObservableObject {
         } catch {
             TFLogger.shared.error("Profile \(profile.name) failed: \(error)")
         }
+        armAutoRevert()
     }
 
     // MARK: - Launch at Login

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -120,6 +120,20 @@ struct MenuBarView: View {
 
             Divider().padding(.vertical, 4)
 
+            // Auto-revert
+            SectionHeader(title: "AUTO-REVERT")
+            Picker("Auto-revert", selection: $appState.autoRevertMinutes) {
+                Text("Off").tag(0)
+                Text("After 15 min").tag(15)
+                Text("After 30 min").tag(30)
+                Text("After 60 min").tag(60)
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+            .padding(.horizontal, 12)
+
+            Divider().padding(.vertical, 4)
+
             // Footer
             Toggle("°F / °C", isOn: $appState.useFahrenheit)
                 .padding(.horizontal, 12)


### PR DESCRIPTION
Implements #17. Adds an optional auto-revert timer — when a non-default profile is active it falls back to Default after 15/30/60 min, off by default. It's a single Timer in AppState next to the heartbeat one, armed when a profile is selected and cleared on reset/quit, plus an inline picker in the menu. No daemon changes, it just calls the existing resetAuto path.

One thing worth your call: right now it arms for any non-default profile including Smart. My thinking was if you set a timer you want it to revert whatever's running, but happy to exclude Smart if you'd rather it run indefinitely — it's a one-liner.

Left it as a draft. Couldn't test fully end to end without a running install on my end, but it builds clean.