### PR TITLE
Fix macOS setup: remove unsupported xattr -r option

### DIFF
--- a/discover.txt
+++ b/discover.txt
@@ -1,0 +1,2137 @@
+ThermalForge Key Dump
+Date: 2026-06-30T07:40:39Z
+Machine: MacBookPro18,3
+macOS: Version 27.0 (Build 26A5368g)
+Keys found: 2129
+────────────────────────────────────────────────────────────────────────
+Key    Type   Size  Value
+────────────────────────────────────────────────────────────────────────
+#KEY   ui32      4  00 00 08 51
+AC-B   si8       1  ff = 255
+AC-C   flag      1  00 = 0
+AC-E   flag      1  00 = 0
+AC-F   ui8       1  00 = 0
+AC-I   ui16      2  00 1c
+AC-J   ui16      2  00 00
+AC-M   hex_      2  01 01
+AC-N   ui8       1  04 = 4
+AC-P   ui8       1  00 = 0
+AC-Q   ui8       1  00 = 0
+AC-R   ui8       1  00 = 0
+AC-S   flag      1  01 = 1
+AC-T   ui8       1  00 = 0
+AC-U   flag      1  00 = 0
+AC-W   si8       1  02 = 2
+AC-X   hex_      2  00 00
+ACAP   ui8       1  00 = 0
+ACBI   hex_      8  01 00 00 00 00 01 00 00
+ACCF   ui8       1  1e = 30
+ACCP   ui8       1  02 = 2
+ACDB   hex_      2  12 05
+ACDI   ui16      2  b2 0c
+ACDL   hex_      1  00 = 0
+ACEC   hex_      8  00 00 00 00 00 00 00 00
+ACFP   flag      1  01 = 1
+ACID   ui8       1  00 = 0
+ACIE   ui32      4  00 00 00 00
+ACKG   hex_    118  
+ACKL   hex_      1  00 = 0
+ACKR   hex_    111  
+ACKS   hex_      2  00 00
+ACLC   ui8       1  01 = 1
+ACLM   ui32      4  00 00 00 00
+ACMg   ui8       1  04 = 4
+ACPK   ui8       1  00 = 0
+ACPO   ui32      4  74 40 00 00
+ACPW   ui32      4  e8 fd 00 00
+ACSt   hex_      4  17 03 00 00
+ACVS   ui8       1  00 = 0
+ACpt   ui8       1  02 = 2
+ADBA   ui32      4  00 00 00 00
+ANWP   ui8       1  04 = 4
+AOPb   ui64      8  00 e1 e6 91 02 00 00 00
+AP-N   ui8       1  04 = 4
+AP1A   hex_     44  
+AP1F   si16      2  f2 05
+AP1I   si16      2  19 01
+AP1P   ui16      2  c4 05
+AP1S   ui8       1  01 = 1
+AP1V   si16      2  7b 14
+AP1i   ui16      2  b8 0b
+AP1p   ui32      4  7a cb 22 00
+AP1q   ui32      4  00 00 00 00
+AP1u   si16      2  00 00
+AP1v   ui16      2  00 00
+AP2A   hex_     44  
+AP2F   si16      2  00 00
+AP2I   si16      2  00 00
+AP2P   ui16      2  00 00
+AP2S   ui8       1  00 = 0
+AP2V   si16      2  00 00
+AP2i   ui16      2  00 00
+AP2p   ui32      4  00 00 00 00
+AP2q   ui32      4  00 00 00 00
+AP2u   si16      2  00 00
+AP2v   ui16      2  00 00
+AP3A   hex_     44  
+AP3F   si16      2  00 00
+AP3I   si16      2  00 00
+AP3P   ui16      2  00 00
+AP3S   ui8       1  00 = 0
+AP3V   si16      2  00 00
+AP3i   ui16      2  00 00
+AP3p   ui32      4  00 00 00 00
+AP3q   ui32      4  00 00 00 00
+AP3u   si16      2  00 00
+AP3v   ui16      2  00 00
+AP4A   hex_     44  
+AP4F   si16      2  00 00
+AP4I   si16      2  00 00
+AP4P   ui16      2  00 00
+AP4S   ui8       1  00 = 0
+AP4V   si16      2  00 00
+AP4i   ui16      2  00 00
+AP4p   ui32      4  00 00 00 00
+AP4q   ui32      4  00 00 00 00
+AP4u   si16      2  00 00
+AP4v   ui16      2  00 00
+ARSD   hex_      3  00 00 00
+ARSP   hex_      3  00 00 00
+ATC0   hex_     53  
+ATC1   hex_     53  
+ATC2   hex_     53  
+ATC3   hex_     53  
+ATP0   hex_     96  
+ATP1   hex_     96  
+ATP2   hex_     96  
+ATP3   hex_     96  
+B0AC   si16      2  f2 f9
+B0AP   si32      4  47 b7 ff ff
+B0AT   ui16      2  f6 0b
+B0AV   ui16      2  eb 2e
+B0BL   ui16      2  00 00
+B0CA   ui16      2  00 00
+B0CH   si16      2  00 00
+B0CI   hex_      4  92 51 00 00
+B0CM   ui8       1  64 = 100
+B0CS   ui16      2  00 00
+B0CT   ui16      2  ea 01
+B0CU   ui16      2  e8 03
+B0DC   ui16      2  bb 17
+B0FC   ui16      2  f6 12
+B0FG   hex_      8  01 00 00 01 00 00 00 00
+B0FH   hex_      8  01 02 f8 7f 00 00 00 00
+B0FI   hex_      2  c0 00
+B0FV   hex_      4  02 00 00 00
+B0HM   ui16      2  00 00
+B0I2   si16      2  00 00
+B0IF   si16      2  00 00
+B0IM   si16      2  00 00
+B0IS   hex_     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+B0IV   si16      2  f2 f9
+B0MS   ui16      2  00 00
+B0MT   ui16      2  4c 00
+B0NC   ui16      2  8c 13
+B0OC   si16      2  00 00
+B0OS   hex_      2  c3 e4
+B0OV   ui16      2  00 00
+B0PS   hex_      2  00 00
+B0QD   ui16      2  00 00
+B0QS   si16      2  00 00
+B0R1   hex_     32  00 fa 00 4a 00 29 00 30 00 38 00 2d 00 37 00 3c 00 3e 00 43 00 47 00 57 00 63 01 11 01 81 00 00
+B0R2   hex_     32  00 dc 00 46 00 27 00 2d 00 38 00 2c 00 37 00 3c 00 3f 00 46 00 4a 00 58 00 6a 00 4a 00 a4 00 00
+B0R3   hex_     32  01 01 00 44 00 2a 00 30 00 3b 00 2e 00 39 00 3e 00 43 00 47 00 49 00 5b 00 69 01 03 01 cc 00 00
+B0RC   ui16      2  96 00
+B0RI   ui16      2  79 1c
+B0RM   ui16      2  43 0f
+B0RS   si16      2  00 00
+B0RV   ui16      2  19 32
+B0S1   si16      2  00 00
+B0SR   si16      2  00 00
+B0SS   ui16      2  00 00
+B0TC   si16      2  00 00
+B0TE   ui16      2  ba 02
+B0TF   ui16      2  ff ff
+B0TI   ui32      4  ff ff 00 00
+B0Ti   ui32      4  00 00 00 00
+B0UC   ui16      2  53 00
+B1AT   ui16      2  4a 01
+B1SS   ui16      2  00 00
+B1TI   flt       4  00 00 20 41
+B1WI   flt       4  00 00 20 41
+B2AT   ui16      2  46 01
+BAAC   si64      8  b1 b4 fe ff ff ff ff ff
+BACC   ui64      8  08 05 00 00 00 00 00 00
+BAPS   flag      1  01 = 1
+BAST   hex_     17  00 00 00 00 00 00 00 00 00 c3 e4 00 02 4e 02 00 02
+BBAD   flag      1  00 = 0
+BC1V   ui16      2  a8 0f
+BC2V   ui16      2  a1 0f
+BC3V   ui16      2  a2 0f
+BCF0   hex_      1  00 = 0
+BCFP   ui32      4  00 00 00 00
+BCFQ   ui8       1  01 = 1
+BCFR   hex_      1  00 = 0
+BCFW   hex_      1  00 = 0
+BCHT   hex_      1  00 = 0
+BCMV   ui16      2  a8 0f
+BCMW   ui16      2  a1 0f
+BCSS   ui8       1  00 = 0
+BDAQ   ui16      2  00 00
+BDBI   hex_     17  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+BDD1   ui8       1  17 = 23
+BDD2   ui8       1  17 = 23
+BDD3   ui8       1  17 = 23
+BDFU   ????      0  
+BFC1   ui16      2  f6 12
+BFC2   ui16      2  f6 12
+BFCT   ui16      2  00 00
+BFLO   ui8       1  00 = 0
+BFLV   ui8       1  00 = 0
+BFS0   ui64      8  02 00 00 00 00 00 00 00
+BFWC   ui16      2  57 35
+BIMX   ui16      2  18 72
+BIPD   ui16      2  44 00
+BISS   si16      2  ea ff
+BITV   ui16      2  28 23
+BL0A   hex_     32  06 d7 20 98 00 19 b9 2e 00 00 00 00 00 00 00 00 06 f0 d9 c6 80 00 c7 e4 40 32 00 00 00 00 00 00
+BL0B   hex_     32  00 2b 00 0a 10 f5 0a ab 32 d7 21 7f 18 4f ea 13 1e 03 e7 1b ea 13 e7 1b 00 f1 00 07 e5 a6 00 16
+BL0C   hex_     28  f1 10 f2 10 f5 10 00 00 96 0b ad 0a ab 0a ff 7f a2 01 d7 32 7f 21 4f 18 13 ea 13 ea
+BL0D   hex_     32  00 00 00 00 0d 00 2f 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+BLCC   ui16      2  e6 01
+BLCM   si16      2  ab 0a
+BLCR   ui8       1  00 = 0
+BLCX   si16      2  f5 10
+BLH0   ui32      4  00 00 00 00
+BLH1   ui32      4  85 09 00 00
+BLH2   ui32      4  78 01 00 00
+BLH3   ui32      4  1a 00 00 00
+BLIC   si16      2  4f 18
+BLID   si16      2  13 ea
+BLPM   si16      2  7f 21
+BLPX   si16      2  d7 32
+BLTA   si16      2  f1 00
+BLTM   si16      2  0a 00
+BLTO   ui32      4  5a 7e 00 00
+BLTP   hex_    112  
+BLTS   si32      4  a6 e5 07 00
+BLTX   si16      2  2b 00
+BMCD   ui16      2  00 00
+BMDA   ch8*     32  00 00 00 00 0b 00 01 00 48 14 00 00 04 31 39 31 34 03 30 30 39 03 41 54 4c 00 07 00 00 00 00 00
+BMDB   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+BMDN   ch8*     32  62 71 34 30 7a 36 35 31 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+BMDT   ch8*      7  33 30 30 33 31 32 00
+BMSC   ui8       1  53 = 83
+BMSN   ch8*     21  46 38 59 32 31 31 32 48 4b 39 46 51 31 4c 54 41 50 00 00 00 00
+BMW1   ch8*      4  00 00 00 00
+BMW2   ch8*      4  00 00 00 00
+BNCB   si8       1  03 = 3
+BNSC   ui8       1  50 = 80
+BNUM   ui8       1  01 = 1
+BPCC   hex_      2  01 01
+BQCC   si16      2  22 00
+BQD1   ui16      2  c0 0e
+BQD2   ui16      2  e0 0e
+BQD3   ui16      2  d0 0e
+BQX1   ui16      2  5c 15
+BQX2   ui16      2  58 15
+BQX3   ui16      2  59 15
+BR00   ui16      2  01 01
+BR01   ui16      2  44 00
+BR02   ui16      2  2a 00
+BR03   ui16      2  30 00
+BR04   ui16      2  3b 00
+BR05   ui16      2  2e 00
+BR06   ui16      2  39 00
+BR07   ui16      2  3e 00
+BR08   ui16      2  43 00
+BR09   ui16      2  47 00
+BR0C   ui16      2  00 00
+BR0W   ui16      2  43 00
+BR10   ui16      2  49 00
+BR11   ui16      2  5b 00
+BR12   ui16      2  69 00
+BR13   ui16      2  03 01
+BR14   ui16      2  cc 01
+BR1W   ui16      2  43 00
+BR2W   ui16      2  40 00
+BR3W   ui16      2  44 00
+BRC0   ui32      4  00 00 00 00
+BRC1   ui32      4  00 00 00 00
+BROS   ui32      4  00 00 00 00
+BRSC   ui8       1  50 = 80
+BSFC   flag      1  00 = 0
+BT0C   flag      1  01 = 1
+BT0L   flag      1  00 = 0
+BT0V   flag      1  00 = 0
+BTHC   ui8       1  00 = 0
+BTHW   ui8       1  00 = 0
+BTIL   ui32      4  8c 13 00 00
+BTRA   hex_     25  0a 0a 0a 0a 0a 0a 19 19 19 19 0a 55 32 32 19 0a 78 64 46 2d 0a 78 64 46 2d
+BTRO   ui8       1  00 = 0
+BTRS   ui8       1  64 = 100
+BTRT   flt       4  00 00 80 3f
+BTSI   ui32      4  8c 13 00 00
+BTSV   ui32      4  59 10 00 00
+BTTA   hex_     10  0c 00 0f 00 14 00 23 00 2d 00
+BTTC   ui8       1  05 = 5
+BTTI   ui8       1  03 = 3
+BTTS   flag      1  00 = 0
+BTVA   hex_     10  b8 0b 27 10 59 10 8b 10 ef 10
+BTVC   ui8       1  05 = 5
+BTVI   ui8       1  02 = 2
+BTVL   ui32      4  59 10 00 00
+BUIC   ui8       1  53 = 83
+BUPT   hex_      8  08 05 00 00 00 00 00 00
+BVCA   hex_     12  64 00 96 00 c8 00 fa 00 e8 03 ff ff
+BVHA   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+BVVA   hex_     12  ef 10 e5 10 d1 10 bd 10 b3 10 81 10
+BVVC   hex_     56  
+BVVI   ui8       1  04 = 4
+BVVL   ui16      2  b3 10
+BVVM   ui16      2  b3 10
+BVVN   ui16      2  b3 10
+BVVO   ui16      2  ef 10
+BVVP   ui16      2  b3 10
+BVVQ   ui16      2  ef 10
+BVVR   ui16      2  b3 10
+BfDC   ui32      4  70 11 01 00
+BfRM   ui32      4  f4 e2 00 00
+BfSC   ui8       1  53 = 83
+BnDC   ui32      4  70 11 01 00
+Bvt0   ui8       1  01 = 1
+Bvt1   ui32      4  5a 7e 00 00
+Bvt2   flt       4  4f 1b 55 3f
+Bvt3   flt       4  00 00 00 00
+Bvt4   flt       4  14 fa d6 be
+Bvt5   flt       4  20 b6 5e bd
+Bvt6   flt       4  20 b6 5e 3d
+Bvt7   flt       4  52 b8 8a 40
+Bvt8   flt       4  52 b8 8a 40
+Bvt9   ui8       1  00 = 0
+Bvta   hex_     28  00 00 00 00 85 09 00 00 78 01 00 00 1a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Bvtb   ui32      4  0b 00 00 00
+Bvtc   ui8       1  00 = 0
+Bvtd   ui32      4  00 00 00 00
+Bvte   hex_     28  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+Bvtf   flt       4  00 00 00 00
+Bvtg   flt       4  00 00 00 00
+Bvth   flt       4  00 00 00 00
+Bvti   flt       4  00 00 00 00
+Bvtj   flt       4  00 00 00 00
+Bvtk   flt       4  00 00 00 00
+Bvtl   flt       4  00 00 00 00
+Bvtm   flt       4  00 00 00 00
+Bvtn   flt       4  00 00 00 00
+Bvto   hex_     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+CBCL   ui32      4  00 00 00 00
+CBD0   hex_    100  
+CBD1   hex_    100  
+CBD2   hex_    100  
+CBD3   hex_    100  
+CBD4   hex_    100  
+CBIV   hex_     20  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+CBPL   hex_      8  00 00 00 00 00 00 00 00
+CBSC   ui32      4  06 00 00 00
+CBSV   ui32      4  04 00 00 00
+CBTC   ui8       1  01 = 1
+CH0D   hex_      4  0c 00 00 00
+CH0E   hex_      8  00 00 00 00 00 00 00 00
+CH0H   ui64      8  00 00 00 00 00 00 00 00
+CH0J   ????      0  
+CH0R   hex_      4  08 00 00 00
+CH0V   ui32      4  eb 2e 00 00
+CHA1   ui32      4  00 00 00 00
+CHA2   ui32      4  18 43 0f 00
+CHAI   ui32      4  00 00 00 00
+CHAS   ui32      4  00 00 00 00
+CHBI   ui32      4  00 00 00 00
+CHBV   ui32      4  da 0f 00 00
+CHCC   ui8       1  00 = 0
+CHCE   ui8       1  00 = 0
+CHCF   hex_      1  00 = 0
+CHCR   ui8       1  00 = 0
+CHDB   hex_      2  00 00
+CHFS   ui32      4  01 00 00 00
+CHHC   ui16      2  00 00
+CHHV   ui64      8  00 00 00 00 00 00 00 00
+CHHW   ui32      4  00 00 00 00
+CHI1   ui32      4  00 00 00 00
+CHI2   ui32      4  00 00 00 00
+CHIB   ui8       1  00 = 0
+CHIC   ui8       1  00 = 0
+CHIE   hex_      1  08 = 8
+CHIF   ui32      4  01 00 00 00
+CHIL   flag      1  00 = 0
+CHIM   ui32      4  88 13 00 00
+CHIO   flag      1  00 = 0
+CHIS   ui32      4  01 00 00 00
+CHLS   ????      0  
+CHLT   hex_      3  00 00 00
+CHM2   hex_     12  ff ff ff ff 00 00 00 00 00 00 00 00
+CHNC   hex_      8  00 10 00 00 00 00 00 00
+CHND   hex_      9  00 00 00 00 00 00 00 00 00
+CHOC   ui32      4  00 00 00 00
+CHPS   ui32      4  01 00 00 00
+CHRT   ui8       1  00 = 0
+CHSC   ui8       1  00 = 0
+CHSE   ui8       1  00 = 0
+CHSL   hex_     64  
+CHST   ui8       1  00 = 0
+CHSW   hex_      8  00 00 00 00 00 00 00 00
+CHTC   ui32      4  00 00 00 00
+CIP0   ui32      4  85 2f 00 00
+CIPC   ui32      4  00 00 00 00
+CIPI   ui32      4  b2 0c 00 00
+CIPP   ui32      4  e8 fd 00 00
+CIPR   ui8       1  ff = 255
+CIPV   ui32      4  20 4e 00 00
+CIPW   ui32      4  30 75 00 00
+CLBT   ui64      8  d1 ed 30 38 f4 0d 00 00
+CLKM   hex_      6  0c 6d 55 89 76 00
+CLKU   ui64      8  e5 7f 17 72 21 0e 00 00
+CLKo   hex_      6  00 00 00 00 00 00
+CLSD   ui64      8  7f 80 e1 6b f1 0d 00 00
+CLSP   ui64      8  00 00 00 00 00 00 00 00
+CLWK   ui64      8  4f ba 4a 25 21 0e 00 00
+CMCR   hex_     16  8a fa ff ff f7 fc ff ff 36 fd ff ff ac fd ff ff
+CMR0   si32      4  8a fa ff ff
+CMR1   si32      4  f7 fc ff ff
+CMR2   si32      4  36 fd ff ff
+CMR3   si32      4  ac fd ff ff
+D1Ac   hex_      4  00 00 00 00
+D1BD   ui32      4  00 00 00 00
+D1BI   ui16      2  00 00
+D1CA   ui16      2  01 00
+D1CD   ui16      2  00 00
+D1CF   ui16      2  00 00
+D1CR   ui16      2  00 00
+D1CS   ui8       1  00 = 0
+D1CT   ui8       1  00 = 0
+D1CU   ui8       1  00 = 0
+D1CX   ui8       1  00 = 0
+D1CY   ui8       1  00 = 0
+D1CZ   ui8       1  00 = 0
+D1Cb   ui8       1  00 = 0
+D1Cc   ui16      2  00 00
+D1Cf   ui16      2  00 00
+D1Ci   ui16      2  00 00
+D1Cm   ui16      2  00 00
+D1Cn   ui16      2  00 00
+D1Cr   ui16      2  00 00
+D1Cs   ui16      2  00 00
+D1Ct   ui16      2  00 00
+D1Cv   ui16      2  00 00
+D1Cw   ui16      2  00 00
+D1DA   hex_      2  01 70
+D1DE   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1DI   ui8       1  02 = 2
+D1DP   hex_      8  00 00 00 00 91 04 00 00
+D1DR   flag      1  01 = 1
+D1Dp   flag      1  00 = 0
+D1EC   ui8       1  00 = 0
+D1EF   hex_      4  00 00 00 00
+D1Ep   flag      1  00 = 0
+D1FC   ui32      4  00 00 00 00
+D1FS   hex_      1  82 = 130
+D1FV   hex_      4  00 21 70 00
+D1IQ   hex_     42  
+D1IR   ui16      2  00 00
+D1JA   ui32      4  98 3a 00 00
+D1JB   ui32      4  4c 1d 00 00
+D1JD   {jst     21  98 3a 00 00 98 3a 00 00 98 3a 4c 1d 4c 1d 4c 1d 98 3a 00 00 03
+D1JE   ui32      4  4c 1d 00 00
+D1JF   ui32      4  98 3a 00 00
+D1JG   ui32      4  98 3a 00 00
+D1JI   flt       4  09 24 90 3e
+D1JM   ui16      2  98 3a
+D1JN   ui16      2  4c 1d
+D1JP   ui8       1  00 = 0
+D1JQ   hex_     18  98 3a 00 00 00 00 00 00 98 3a 00 00 4c 1d 00 00 00 00
+D1JR   si32      4  98 3a 00 00
+D1JS   si32      4  4c 1d 00 00
+D1JV   flt       4  f2 c9 a7 40
+D1LC   ui8       1  00 = 0
+D1LG   hex_    120  
+D1LI   ui8       1  17 = 23
+D1LR   ui8       1  01 = 1
+D1MI   ui16      2  00 00
+D1MP   ui32      4  00 00 00 00
+D1MV   ui16      2  00 00
+D1PI   si8       1  00 = 0
+D1PM   hex_     28  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1PR   ui8       1  01 = 1
+D1PS   ui8       1  ff = 255
+D1PT   ui8       1  00 = 0
+D1Pd   hex_      2  01 78
+D1Pe   hex_      2  00 00
+D1Pi   ui16      2  00 00
+D1Ps   ui8       1  ff = 255
+D1Pt   ui8       1  00 = 0
+D1Rc   ui16      2  00 00
+D1Rp   ui16      2  00 00
+D1ST   ui8       1  00 = 0
+D1SW   ui8       1  64 = 100
+D1St   hex_      2  73 00
+D1UI   hex_     16  e3 b6 a8 1c ba 36 5a 97 11 4e ec dd 0d b6 ec de
+D1VD   flt       4  00 00 00 00
+D1VM   ui16      2  00 00
+D1VR   ui16      2  00 00
+D1VX   ui16      2  00 00
+D1Vb   ui8       1  02 = 2
+D1Vd   hex_      2  ac 05
+D1Ve   hex_      2  00 00
+D1Vm   ui8       1  00 = 0
+D1Vn   ui8       1  00 = 0
+D1WS   flag      1  01 = 1
+D1if   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D1ih   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D1ii   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1im   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1in   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1is   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1lg   hex_     30  1a 03 bb a0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D1li   ui8       1  04 = 4
+D1pd   flag      1  01 = 1
+D1pi   flag      1  00 = 0
+D1pr   ui8       1  01 = 1
+D1pt   ui8       1  00 = 0
+D2Ac   hex_      4  13 84 b1 2c
+D2BD   ui8       1  0c = 12
+D2BI   ui16      2  f4 01
+D2CA   ui16      2  00 00
+D2CD   ui16      2  00 00
+D2CF   ui16      2  00 00
+D2CR   ui16      2  00 01
+D2CS   ui8       1  00 = 0
+D2CT   ui8       1  00 = 0
+D2CU   ui8       1  00 = 0
+D2CX   ui8       1  00 = 0
+D2CY   ui8       1  00 = 0
+D2CZ   ui8       1  00 = 0
+D2Cb   ui8       1  00 = 0
+D2Cc   ui16      2  00 00
+D2Cf   ui16      2  00 00
+D2Ci   ui16      2  00 00
+D2Cm   ui16      2  00 00
+D2Cn   ui16      2  00 00
+D2Cr   ui16      2  00 00
+D2Cs   ui16      2  00 00
+D2Ct   ui16      2  00 00
+D2Cv   ui16      2  00 00
+D2Cw   ui16      2  00 00
+D2DA   hex_      2  01 7e
+D2DE   ch8*     32  70 64 20 63 68 61 72 67 65 72 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2DI   ui8       1  02 = 2
+D2DP   hex_      8  00 00 ff 01 99 a4 00 00
+D2DR   flag      1  01 = 1
+D2Dp   flag      1  01 = 1
+D2EC   ui8       1  00 = 0
+D2EF   hex_      4  00 00 00 00
+D2Ep   flag      1  01 = 1
+D2FC   ui32      4  0a 40 00 e0
+D2FS   hex_      1  0c = 12
+D2FV   hex_      4  00 21 70 00
+D2IQ   hex_     42  
+D2IR   ui16      2  b2 0c
+D2JA   ui32      4  4c 1d 00 00
+D2JB   ui32      4  4c 1d 00 00
+D2JD   {jst     21  00 00 00 00 00 00 00 00 4c 1d 4c 1d 00 00 00 00 4c 1d 00 00 00
+D2JE   ui32      4  00 00 00 00
+D2JF   ui32      4  00 00 00 00
+D2JG   ui32      4  00 00 00 00
+D2JI   flt       4  00 00 00 00
+D2JM   ui16      2  98 3a
+D2JN   ui16      2  4c 1d
+D2JP   ui8       1  00 = 0
+D2JQ   hex_     18  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2JR   si32      4  4c 1d 00 00
+D2JS   si32      4  4c 1d 00 00
+D2JV   flt       4  00 00 00 00
+D2LC   ui8       1  00 = 0
+D2LG   hex_    120  
+D2LI   ui8       1  0f = 15
+D2LR   ui8       1  00 = 0
+D2MI   ui16      2  0c b2
+D2MP   ui32      4  00 00 fd e8
+D2MV   ui16      2  4e 20
+D2PI   si8       1  04 = 4
+D2PM   hex_     28  88 13 b8 0b 28 23 b8 0b e0 2e b8 0b 98 3a b8 0b 20 4e b2 0c 00 00 00 00 00 00 00 00
+D2PR   ui8       1  00 = 0
+D2PS   ui8       1  ff = 255
+D2PT   ui8       1  02 = 2
+D2Pd   hex_      2  02 71
+D2Pe   hex_      2  00 00
+D2Pi   ui16      2  00 00
+D2Ps   ui8       1  ff = 255
+D2Pt   ui8       1  01 = 1
+D2Rc   ui16      2  00 00
+D2Rp   ui16      2  00 00
+D2ST   ui8       1  03 = 3
+D2St   hex_      2  53 00
+D2UI   hex_     16  3f 3f a4 1c d0 8b 00 8c bf 4e 51 d5 ea 2d ba 41
+D2VD   flt       4  00 00 00 00
+D2VM   ui16      2  4e 20
+D2VR   ui16      2  20 4e
+D2VX   ui16      2  4e 20
+D2Vb   ui8       1  02 = 2
+D2Vd   hex_      2  5c 1d
+D2Ve   hex_      2  00 00
+D2Vm   ui8       1  00 = 0
+D2Vn   ui8       1  00 = 0
+D2WS   flag      1  01 = 1
+D2if   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D2ih   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D2ii   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2im   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2in   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2is   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2lg   hex_     30  1a 31 48 40 01 3f f3 30 05 bb a0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D2li   ui8       1  0b = 11
+D2pd   flag      1  01 = 1
+D2pi   flag      1  01 = 1
+D2pr   ui8       1  02 = 2
+D2pt   ui8       1  02 = 2
+D3Ac   hex_      4  00 00 00 00
+D3BD   ui8       1  00 = 0
+D3BI   ui16      2  00 00
+D3CA   ui16      2  00 00
+D3CD   ui16      2  00 00
+D3CF   ui16      2  00 00
+D3CR   ui16      2  00 00
+D3CS   ui8       1  00 = 0
+D3CT   ui8       1  00 = 0
+D3CU   ui8       1  00 = 0
+D3CX   ui8       1  00 = 0
+D3CY   ui8       1  00 = 0
+D3CZ   ui8       1  00 = 0
+D3Cb   ui8       1  00 = 0
+D3Cc   ui16      2  00 00
+D3Cf   ui16      2  00 00
+D3Ci   ui16      2  00 00
+D3Cm   ui16      2  00 00
+D3Cn   ui16      2  00 00
+D3Cr   ui16      2  00 00
+D3Cs   ui16      2  00 00
+D3Ct   ui16      2  00 00
+D3Cv   ui16      2  00 00
+D3Cw   ui16      2  00 00
+D3DA   hex_      2  01 76
+D3DE   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3DI   ui8       1  02 = 2
+D3DP   hex_      8  00 00 00 00 00 00 00 00
+D3DR   flag      1  01 = 1
+D3Dp   flag      1  00 = 0
+D3EC   ui8       1  00 = 0
+D3EF   hex_      4  00 00 00 00
+D3Ep   flag      1  00 = 0
+D3FC   ui32      4  00 00 00 00
+D3FS   hex_      1  00 = 0
+D3FV   hex_      4  00 21 70 00
+D3IQ   hex_     42  
+D3IR   ui16      2  00 00
+D3JA   ui32      4  4c 1d 00 00
+D3JB   ui32      4  4c 1d 00 00
+D3JD   {jst     21  00 00 00 00 00 00 00 00 4c 1d 4c 1d 00 00 00 00 4c 1d 00 00 00
+D3JE   ui32      4  00 00 00 00
+D3JF   ui32      4  00 00 00 00
+D3JG   ui32      4  00 00 00 00
+D3JI   flt       4  00 00 00 00
+D3JM   ui16      2  98 3a
+D3JN   ui16      2  4c 1d
+D3JP   ui8       1  00 = 0
+D3JQ   hex_     18  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3JR   si32      4  4c 1d 00 00
+D3JS   si32      4  4c 1d 00 00
+D3JV   flt       4  00 00 00 00
+D3LC   ui8       1  00 = 0
+D3LG   hex_    120  
+D3LI   ui8       1  00 = 0
+D3LR   ui8       1  01 = 1
+D3MI   ui16      2  00 00
+D3MP   ui32      4  00 00 00 00
+D3MV   ui16      2  00 00
+D3PI   si8       1  00 = 0
+D3PM   hex_     28  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3PR   ui8       1  00 = 0
+D3PS   ui8       1  ff = 255
+D3PT   ui8       1  00 = 0
+D3Pd   hex_      2  00 00
+D3Pe   hex_      2  00 00
+D3Pi   ui16      2  00 00
+D3Ps   ui8       1  ff = 255
+D3Pt   ui8       1  00 = 0
+D3Rc   ui16      2  00 00
+D3Rp   ui16      2  00 00
+D3ST   ui8       1  00 = 0
+D3St   hex_      2  00 00
+D3UI   hex_     16  de 6a a8 1c 3e af d3 ba b6 4e 62 26 4d 7e 41 14
+D3VD   flt       4  00 00 00 00
+D3VM   ui16      2  00 00
+D3VR   ui16      2  00 00
+D3VX   ui16      2  00 00
+D3Vb   ui8       1  00 = 0
+D3Vd   hex_      2  00 00
+D3Ve   hex_      2  00 00
+D3Vm   ui8       1  00 = 0
+D3Vn   ui8       1  00 = 0
+D3WS   flag      1  01 = 1
+D3if   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D3ih   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D3ii   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3im   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3in   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3is   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3lg   hex_     30  1a 03 bb a0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D3li   ui8       1  04 = 4
+D3pd   flag      1  00 = 0
+D3pi   flag      1  00 = 0
+D3pr   ui8       1  00 = 0
+D3pt   ui8       1  00 = 0
+D4Ac   hex_      4  00 00 00 00
+D4Au   ui8       1  00 = 0
+D4BD   ui8       1  00 = 0
+D4BI   ui16      2  00 00
+D4CA   ui16      2  00 00
+D4CD   ui16      2  00 00
+D4CF   ui16      2  00 00
+D4CR   ui16      2  00 00
+D4CS   ui8       1  00 = 0
+D4CT   ui8       1  00 = 0
+D4CU   ui8       1  00 = 0
+D4CX   ui8       1  00 = 0
+D4CY   ui8       1  00 = 0
+D4CZ   ui8       1  00 = 0
+D4Cb   ui8       1  00 = 0
+D4Cc   ui16      2  00 00
+D4Cf   ui16      2  00 00
+D4Ci   ui16      2  00 00
+D4Cm   ui16      2  00 00
+D4Cn   ui16      2  00 00
+D4Cr   ui16      2  00 00
+D4Cs   ui16      2  00 00
+D4Ct   ui16      2  00 00
+D4Cv   ui16      2  00 00
+D4Cw   ui16      2  00 00
+D4DA   hex_      2  01 74
+D4DE   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4DI   ui8       1  02 = 2
+D4DP   hex_      8  00 00 00 00 00 00 00 00
+D4DR   flag      1  01 = 1
+D4Dp   flag      1  00 = 0
+D4EC   ui8       1  00 = 0
+D4EF   hex_      4  00 00 00 00
+D4Ep   flag      1  00 = 0
+D4FC   ui32      4  00 00 00 00
+D4FS   hex_      1  00 = 0
+D4FV   hex_      4  00 21 70 00
+D4IQ   hex_     42  
+D4IR   ui16      2  00 00
+D4JA   ui32      4  4c 1d 00 00
+D4JB   ui32      4  4c 1d 00 00
+D4JD   {jst     21  00 00 00 00 00 00 00 00 4c 1d 4c 1d 00 00 00 00 4c 1d 00 00 00
+D4JE   ui32      4  00 00 00 00
+D4JF   ui32      4  00 00 00 00
+D4JG   ui32      4  00 00 00 00
+D4JI   flt       4  00 00 00 00
+D4JM   ui16      2  98 3a
+D4JN   ui16      2  4c 1d
+D4JP   ui8       1  00 = 0
+D4JQ   hex_     18  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4JR   si32      4  4c 1d 00 00
+D4JS   si32      4  4c 1d 00 00
+D4JV   flt       4  00 00 00 00
+D4LC   ui8       1  00 = 0
+D4LG   hex_    120  
+D4LI   ui8       1  46 = 70
+D4LR   ui8       1  01 = 1
+D4MI   ui16      2  00 00
+D4MP   ui32      4  00 00 00 00
+D4MV   ui16      2  00 00
+D4PI   si8       1  00 = 0
+D4PM   hex_     28  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4PR   ui8       1  00 = 0
+D4PS   ui8       1  ff = 255
+D4PT   ui8       1  00 = 0
+D4Pd   hex_      2  00 00
+D4Pe   hex_      2  00 00
+D4Pi   ui16      2  00 00
+D4Ps   ui8       1  ff = 255
+D4Pt   ui8       1  00 = 0
+D4Rc   ui16      2  00 00
+D4Rp   ui16      2  00 00
+D4ST   ui8       1  00 = 0
+D4St   hex_      2  00 00
+D4UI   hex_     16  b6 a6 a3 1c a3 4f 98 97 90 4a 57 83 51 9d 29 aa
+D4VD   flt       4  00 00 00 00
+D4VM   ui16      2  00 00
+D4VR   ui16      2  00 00
+D4VX   ui16      2  00 00
+D4Vb   ui8       1  00 = 0
+D4Vd   hex_      2  00 00
+D4Ve   hex_      2  00 00
+D4Vm   ui8       1  00 = 0
+D4Vn   ui8       1  00 = 0
+D4WS   flag      1  01 = 1
+D4if   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D4ih   ch8*     12  00 00 00 00 00 00 00 00 00 00 00 00
+D4ii   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4im   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4in   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4is   ch8*     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4lg   hex_     30  1a 03 bb a0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+D4li   ui8       1  04 = 4
+D4pd   flag      1  00 = 0
+D4pi   flag      1  00 = 0
+D4pr   ui8       1  00 = 0
+D4pt   ui8       1  00 = 0
+DBCF   ui8       1  86 = 134
+DBTE   ui8       1  01 = 1
+DCAL   hex_     64  
+DICT   flag      1  00 = 0
+DITT   si32      4  00 00 00 00
+DPBS   ui32      4  30 75 00 00
+DPBW   ui32      4  c8 af 00 00
+DULT   ui8       1  46 = 70
+DUST   ui8       1  00 = 0
+DUTC   flag      1  01 = 1
+DUTT   ui8       1  2d = 45
+EVPF   hex_     16  10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+F0Ac   flt       4  9f 04 3a 45 = 2976 RPM
+F0Dc   flt       4  22 f4 89 3e = 0 RPM
+F0Fb   ui8       1  01 = 1
+F0Fc   ui16      2  00 04
+F0Md   ui8       1  01 = 1
+F0Mn   flt       4  00 00 96 44 = 1200 RPM
+F0Mx   flt       4  00 98 b4 45 = 5779 RPM
+F0Sf   ui16      2  00 00
+F0St   ui8       1  05 = 5
+F0Tg   flt       4  00 90 36 45 = 2921 RPM
+F1Ac   flt       4  48 8b 39 45 = 2968 RPM
+F1Dc   flt       4  14 65 8c 3e = 0 RPM
+F1Fb   ui8       1  01 = 1
+F1Fc   ui16      2  00 04
+F1Md   ui8       1  01 = 1
+F1Mn   flt       4  00 00 96 44 = 1200 RPM
+F1Mx   flt       4  00 08 c3 45 = 6241 RPM
+F1Sf   ui16      2  00 00
+F1St   ui8       1  05 = 5
+F1Tg   flt       4  00 90 36 45 = 2921 RPM
+FBAD   hex_      4  00 00 00 00
+FNum   ui8       1  02 = 2
+FOFC   ui32      4  00 00 00 00
+FOff   ui8       1  01 = 1
+FRmp   ui16      2  00 00
+I5SR   flt       4  27 5e 6b 3d
+IA1R   flt       4  00 00 00 00
+ICMC   flt       4  00 00 00 00
+ID0R   flt       4  d2 97 c8 3b
+ID3C   flt       4  00 00 00 00
+IDBC   flt       4  00 00 00 00
+IDBR   flt       4  1f f0 ee 3e
+IDHC   flt       4  00 00 00 00
+IH0R   flt       4  00 00 00 00
+IH1R   flt       4  00 00 00 00
+IHCR   flt       4  00 00 00 00
+IHDR   flt       4  00 00 00 00
+IINC   flt       4  00 00 00 00
+IKBC   flt       4  00 00 00 00
+IMVC   flt       4  fc 38 a9 3f
+IMVR   flt       4  7e 25 09 3f
+IP0b   flt       4  00 bf 1b 3f
+IP0s   flt       4  00 00 00 00
+IP1b   flt       4  00 00 00 00
+IP1l   flt       4  00 00 68 3b
+IP2b   flt       4  00 10 52 3d
+IP2l   flt       4  00 00 04 3c
+IP3b   flt       4  00 a0 f1 3d
+IP3l   flt       4  00 00 00 00
+IP4b   flt       4  00 d0 c1 3d
+IP5b   flt       4  00 00 00 00
+IP5l   flt       4  00 00 df 3c
+IP6b   flt       4  00 00 a8 3b
+IP7b   flt       4  00 00 00 00
+IP8b   flt       4  00 18 a8 3d
+IP9b   flt       4  00 14 13 3e
+IPBR   flt       4  a8 85 d9 3f
+IPMC   flt       4  e7 88 f3 3e
+IPSC   flt       4  c0 04 08 3f
+IPab   flt       4  00 00 00 00
+IR0b   flt       4  80 51 d8 3f
+IR0l   flt       4  00 00 8e 3c
+IR0s   flt       4  00 00 00 00
+IR1b   flt       4  00 00 00 00
+IR1l   flt       4  00 00 80 3a
+IR2b   flt       4  00 00 00 00
+IR3b   flt       4  00 a0 f1 3d
+IR4b   flt       4  00 00 00 00
+IR5b   flt       4  00 00 00 00
+IR6b   flt       4  00 20 e7 3d
+IR8b   flt       4  00 10 93 3d
+IR9b   flt       4  00 98 c7 3d
+IRab   flt       4  00 9e ef 3e
+ISDR   flt       4  00 00 00 00
+ISVC   flt       4  3d 2d 47 40
+ISVR   flt       4  e6 66 02 3f
+IU1C   flt       4  00 00 00 00
+IU1R   flt       4  3c fd 1e 3e
+IU2C   flt       4  00 00 00 00
+IU2R   flt       4  11 08 c3 3a
+IW3C   flt       4  00 00 00 00
+Ib0f   flt       4  99 91 d9 3f
+Ib8f   flt       4  bb a2 43 40
+KDBG   ui8       1  01 = 1
+KDD0   hex_     32  d5 82 1a 6c e6 5f 9d b8 00 00 6b 77 bd 86 3d 31 b5 04 6e a6 e0 63 ca ad 12 58 55 5d d4 1c e7 83
+KDD1   hex_     32  b9 25 0e 6d 7c d6 22 9d 79 aa 00 00 cc 42 27 48 00 00 43 b0 00 00 00 00 fc 29 00 00 c6 f1 00 00
+KDTP   ui8       1  01 = 1
+KINC   ui16      2  00 eb
+KINV   ch8*      4  43 48 54 45
+KINX   hex_      4  43 48 54 45
+LCAD   ui8       1  07 = 7
+LCAE   ui8       1  00 = 0
+LDKN   ui8       1  03 = 3
+LGDA   ui64      8  00 d0 e6 91 02 00 00 00
+LGDB   ui64      8  00 00 00 00 00 00 00 00
+LGDC   ui64      8  00 00 00 00 00 00 00 00
+LGDS   ui64      8  00 04 00 00 00 00 00 00
+LGPE   flag      1  00 = 0
+MBSE   hex_      4  fe 00 00 00
+MBSW   hex_      8  00 00 00 00 00 00 00 00
+MBSe   hex_      8  00 00 00 00 00 00 00 00
+MBSw   hex_      8  00 00 00 00 00 00 00 00
+MDSV   hex_      9  00 00 01 07 01 02 00 10 00
+MEKV   ui16      2  00 01
+MEPS   hex_      6  00 04 00 04 00 01
+MESS   ui8       1  2a = 42
+MEST   hex_      8  5d 90 35 25 21 0e 00 00
+MEWE   ui8       1  01 = 1
+MFIC   hex_      4  00 00 00 00
+MFIX   flag      1  00 = 0
+MPPR   ui32      4  00 00 00 01
+MSAL   hex_      1  08 = 8
+MSAM   ui8       1  03 = 3
+MSFL   ch8*      4  00 00 00 00
+MSFN   ui8       1  00 = 0
+MSKT   ui32      4  00 00 00 00
+MSLD   ui8       1  00 = 0
+MSLm   flt       4  00 00 80 3f
+MSLn   flt       4  00 00 dc 42
+MSMR   ui8       1  00 = 0
+MSMV   flt       4  00 00 d8 41
+MSOC   si32      4  00 00 00 1a
+MSOP   si32      4  00 00 00 06
+MSOR   si32      4  00 00 00 06
+MSSC   flag      1  00 = 0
+MST3   ui32      4  00 00 00 00
+MST6   ui64      8  00 00 00 00 00 00 00 00
+MSTC   ui16      2  00 00
+MSTD   ui16      2  00 00
+MSX0   ui16      2  30 b1
+MSX2   ui8       1  0c = 12
+MSX9   ui8       1  30 = 48
+MSXA   ch8*      4  6d 6c 50 32
+MSXC   ui32      4  00 00 00 00
+MSXD   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+MSXH   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+MSXK   ch8*     32  01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20
+MSXL   ch8*     16  28 6b 6e 4e 28 6b 6e 4e 28 6b 6e 4e 28 6b 6e 4e
+MSXN   ui8       1  b2 = 178
+MSXP   ui32      4  00 00 00 00
+MSXS   ch8*      4  01 02 03 04
+MSXT   ui32      4  ff ff ff ff
+MSXU   hex_      2  00 00
+MSXZ   flt       4  00 00 00 00
+MSXb   ui8       1  00 = 0
+MSXc   ui32      4  00 00 00 00
+MSXd   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+MSXh   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+MSXk   ch8*     32  01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f 20
+MSXl   ch8*     16  28 6b 6e 4e 28 6b 6e 4e 28 6b 6e 4e 28 6b 6e 4e
+MSXm   ui16      2  00 08
+MSXn   ui8       1  59 = 89
+MSXs   ui32      4  01 02 03 04
+MSXt   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+MSxb   hex_      2  03 3f
+MSxd   hex_     32  03 3f 00 00 26 04 00 00 00 00 46 4b 31 01 54 40 00 00 00 80 e4 87 51 40 00 00 00 e8 58 42 83 40
+MSxs   hex_     16  03 42 00 00 57 04 00 00 00 00 de da 83 28 45 40
+MpPC   ui16      2  00 00
+MpPD   ui16      2  00 00
+MpPI   ui8       1  00 = 0
+MpPM   ui8       1  00 = 0
+MpPN   ui8       1  00 = 0
+MpPO   ui8       1  00 = 0
+MpPP   ui8       1  00 = 0
+MpPS   ui8       1  00 = 0
+MpPU   ui8       1  00 = 0
+MpPV   ui8       1  00 = 0
+N0Tr   ui8       1  00 = 0
+N0Tw   ui8       1  00 = 0
+NESN   hex_      4  00 00 00 00
+NTAP   flag      1  01 = 1
+Ns0T   ui8       1  01 = 1
+Ns1T   ui8       1  00 = 0
+NsNL   ui8       1  01 = 1
+P5SR   flt       4  08 d2 30 3f
+PA1R   flt       4  00 00 00 00
+PBAT   flt       4  00 00 00 00
+PCMC   flt       4  00 00 00 00
+PD3C   flt       4  00 00 00 00
+PDBC   flt       4  00 00 00 00
+PDBR   flt       4  34 8c b3 40
+PDHC   flt       4  00 00 00 00
+PDTR   flt       4  a9 59 fa 3d
+PH0R   flt       4  00 00 00 00
+PH1R   flt       4  00 00 00 00
+PHCR   flt       4  00 00 00 00
+PHDR   flt       4  00 00 00 00
+PHPB   flt       4  00 00 48 43
+PHPC   flt       4  4a 23 38 41
+PHPM   flt       4  0a d7 63 3f
+PHPS   flt       4  d6 f4 c3 40
+PHPV   flt       4  00 00 48 43
+PINC   flt       4  00 00 00 00
+PKBC   flt       4  00 00 00 00
+PMVC   flt       4  22 aa a0 40
+PMVR   flt       4  40 00 ce 40
+PP0b   flt       4  00 4e 00 3f
+PP0s   flt       4  00 00 00 00
+PP1b   flt       4  00 00 00 00
+PP1l   flt       4  48 c6 3f 3c
+PP2b   flt       4  38 49 42 3d
+PP2l   flt       4  70 e3 6d 3c
+PP3b   flt       4  f7 22 59 3e
+PP3l   flt       4  00 00 00 00
+PP4b   flt       4  bb 78 ca 3d
+PP5b   flt       4  00 00 00 00
+PP5l   flt       4  b4 65 b2 3c
+PP6b   flt       4  e8 1e bc 3b
+PP7b   flt       4  00 00 00 00
+PP8b   flt       4  b2 73 ce 3d
+PP9b   flt       4  71 56 ee 3d
+PPBR   flt       4  e4 58 a3 41
+PPMC   flt       4  08 3c e7 3f
+PPSC   flt       4  02 21 01 40
+PPab   flt       4  00 00 00 00
+PR0b   flt       4  38 ca bb 3f
+PR0l   flt       4  10 ad 55 3c
+PR0s   flt       4  00 00 00 00
+PR1b   flt       4  00 00 00 00
+PR1l   flt       4  00 00 00 00
+PR2b   flt       4  00 00 00 00
+PR3b   flt       4  36 fd 58 3e
+PR4b   flt       4  00 00 00 00
+PR5b   flt       4  00 00 00 00
+PR6b   flt       4  d0 e1 c7 3d
+PR8b   flt       4  74 c8 b4 3d
+PR9b   flt       4  09 99 e0 3d
+PRab   flt       4  8c 83 9e 3e
+PSDR   flt       4  00 00 00 00
+PSTR   flt       4  3c ea 8b 41
+PSVC   flt       4  f4 a5 b3 40
+PSVR   flt       4  3c b0 c3 40
+PU1C   flt       4  00 00 00 00
+PU1R   flt       4  5f e4 ee 3f
+PU2C   flt       4  00 00 00 00
+PU2R   flt       4  22 86 92 3c
+PW3C   flt       4  00 00 00 00
+PZC0   flt       4  4c 4a c6 40
+PZC1   flt       4  ea 21 a6 40
+PZCB   flt       4  00 00 00 00
+PZCU   flt       4  2d 7f 9e 3e
+Pb0f   flt       4  9a 5f a3 41
+RBID   ui32      4  00 00 00 08
+RBRV   ui32      4  00 00 00 09
+RCID   ui32      4  00 00 60 00
+RCRV   ui32      4  00 00 00 21
+RECI   ui64      8  00 0a 29 68 2e d8 80 1e
+RESV   ch8*     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+RGEN   ui8       1  04 = 4
+RPF0   ui8       1  00 = 0
+RPlt   ch8*      8  6a 33 31 34 73 00 00 00
+RUID   ch8*     37  
+RVER   ch8*    120  
+SAQ1   flt       4  33 33 bb 41
+SAQ2   flt       4  00 00 d0 41
+SAQ3   flt       4  cd cc e4 41
+SAQ4   flt       4  9a 99 f9 41
+SAQa   ui32      4  00 00 00 00
+SAQb   ui32      4  00 00 00 00
+SAQc   ui32      4  00 00 00 00
+SAQd   ui32      4  00 00 00 00
+SAQv   ui8       1  10 = 16
+SAQw   ui16      2  00 23
+SAQx   ui8       1  00 = 0
+SAQy   ui8       1  03 = 3
+SAQz   ui8       1  00 = 0
+SAR1   flt       4  9a 99 19 41
+SAR2   flt       4  cd cc 2c 41
+SAR3   flt       4  00 00 40 41
+SAR4   flt       4  33 33 53 41
+SARa   ui32      4  00 00 00 00
+SARb   ui32      4  00 00 00 00
+SARc   ui32      4  00 00 00 00
+SARd   ui32      4  00 00 00 00
+SARv   ui8       1  0f = 15
+SARw   ui16      2  00 23
+SARx   ui8       1  00 = 0
+SARy   ui8       1  03 = 3
+SARz   ui8       1  00 = 0
+SBA1   flt       4  89 41 80 40
+SBA2   flt       4  31 08 80 40
+SBA3   flt       4  31 08 80 40
+SBAA   flt       4  00 00 80 3f
+SBAC   flt       4  67 66 c6 3f
+SBAL   flt       4  00 00 00 00
+SBAP   flt       4  b7 ef 94 41
+SBAR   flt       4  00 30 74 45
+SBAS   flt       4  00 00 a0 42
+SBAV   flt       4  0e 2d 40 41
+SBAW   flt       4  00 00 82 42
+SBAm   flt       4  00 00 80 3f
+SBAn   flt       4  00 00 dc 42
+SDM0   flt       4  00 00 00 00
+SDM1   flt       4  00 00 00 00
+SDM2   flt       4  00 00 00 00
+SDM3   flt       4  00 00 00 00
+SDM4   flt       4  00 00 00 00
+SDM5   flt       4  00 00 00 00
+SDM6   flt       4  00 00 00 00
+SDM7   flt       4  00 00 00 00
+SDM8   flt       4  00 00 00 00
+SDM9   flt       4  00 00 00 00
+SDMA   flt       4  00 00 00 00
+SDMB   flt       4  00 00 00 00
+SDMC   flt       4  00 00 00 00
+SDMD   flt       4  00 00 00 00
+SDME   flt       4  00 00 00 00
+SDMF   flt       4  00 00 00 00
+SDMX   flt       4  00 00 00 00
+SDN0   flt       4  00 00 00 00
+SDN1   flt       4  00 00 00 00
+SDN2   flt       4  00 00 00 00
+SDN3   flt       4  00 00 00 00
+SDN4   flt       4  00 00 00 00
+SDN5   flt       4  00 00 00 00
+SDN6   flt       4  00 00 00 00
+SDN7   flt       4  00 00 00 00
+SDN8   flt       4  00 00 00 00
+SDN9   flt       4  00 00 00 00
+SDNA   flt       4  00 00 00 00
+SDNB   flt       4  00 00 00 00
+SDNC   flt       4  00 00 00 00
+SDND   flt       4  00 00 00 00
+SDNE   flt       4  00 00 00 00
+SDNF   flt       4  00 00 00 00
+SDTo   flt       4  00 00 00 00
+SDTp   flt       4  00 00 00 00
+SEB0   hex_      4  00 00 00 00
+SEB1   hex_      4  00 00 00 00
+SEB2   hex_      4  00 00 00 00
+SEB3   hex_      4  00 00 00 00
+SEB4   hex_      4  00 00 00 00
+SEB5   hex_      4  00 00 00 00
+SEB6   hex_      4  00 00 00 00
+SEB7   hex_      4  00 00 00 00
+SEB8   hex_      4  00 00 00 00
+SEC0   hex_      4  00 00 00 00
+SEC1   hex_      4  00 00 00 00
+SEC2   hex_      4  00 00 00 00
+SEF0   hex_      4  00 00 00 00
+SEF1   hex_      4  00 00 00 00
+SEF2   hex_      4  00 00 00 00
+SES0   hex_      4  00 0c 00 00
+SES1   hex_      4  00 00 00 00
+SES2   hex_      4  00 00 00 00
+SES3   hex_      4  0e 00 00 00
+SES4   hex_      4  00 00 00 00
+SES5   hex_      4  00 00 00 00
+SES6   hex_      4  00 00 00 00
+SES7   hex_      4  00 00 00 00
+SES8   hex_      4  00 00 00 00
+SEb0   hex_      4  00 00 00 00
+SEb1   hex_      4  00 00 00 00
+SEb2   hex_      4  00 00 00 00
+SEb3   hex_      4  00 00 00 00
+SEb4   hex_      4  00 00 00 00
+SEb5   hex_      4  00 00 00 00
+SEb6   hex_      4  00 00 00 00
+SEb7   hex_      4  00 00 00 00
+SEb8   hex_      4  00 00 00 00
+SEc0   hex_      4  00 00 00 00
+SEc1   hex_      4  00 00 00 00
+SEc2   hex_      4  00 00 00 00
+SEf0   hex_      4  00 00 00 00
+SEf1   hex_      4  00 00 00 00
+SEf2   hex_      4  00 00 00 00
+SEs0   hex_      4  00 0c 00 00
+SEs1   hex_      4  00 00 00 00
+SEs2   hex_      4  00 00 00 00
+SEs3   hex_      4  0e 00 00 00
+SEs4   hex_      4  00 00 00 00
+SEs5   hex_      4  00 00 00 00
+SEs6   hex_      4  00 00 00 00
+SEs7   hex_      4  00 00 00 00
+SEs8   hex_      4  00 00 00 00
+SFBN   hex_      4  00 00 00 00
+SFBS   hex_      4  00 00 00 00
+SFF0   hex_      4  00 00 00 00
+SFF1   hex_      4  00 00 00 00
+SFF2   hex_      4  00 00 00 00
+SFF3   hex_      4  00 00 00 00
+SFF4   hex_      4  00 00 00 00
+SFF5   hex_      4  00 00 00 00
+SFF6   hex_      4  00 00 00 00
+SFF7   hex_      4  00 00 00 00
+SFI0   hex_      4  00 00 00 00
+SMB0   hex_     32  53 67 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMB1   hex_     32  ee 17 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMB2   hex_     32  24 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0a 05 00 00 0a f0 00 10
+SMB3   hex_     32  0e 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMB4   hex_     32  31 23 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMB5   hex_     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMB6   hex_     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SMBC   hex_      6  00 00 00 00 00 00
+SMBD   hex_    120  
+SMBE   hex_    120  
+SMBG   ui8       1  00 = 0
+SMBR   hex_     33  
+SMBS   hex_      2  00 00
+SMBU   hex_    120  
+SMBV   hex_    120  
+SMBW   hex_     32  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+SSMH   hex_     40  
+TAOL   flt       4  00 00 f8 41 = 31.0 C
+TB0T   flt       4  00 00 04 42 = 33.0 C
+TB1T   flt       4  00 00 04 42 = 33.0 C
+TB2T   flt       4  64 66 02 42 = 32.6 C
+TC10   flt       4  c3 08 43 42 = 48.8 C
+TC11   flt       4  f9 fd 47 42 = 50.0 C
+TC12   flt       4  aa 6f 43 42 = 48.9 C
+TC13   flt       4  7e 73 46 42 = 49.6 C
+TC20   flt       4  53 8a 3d 42 = 47.4 C
+TC21   flt       4  b9 b1 41 42 = 48.4 C
+TC22   flt       4  e0 8c 3f 42 = 47.9 C
+TC23   flt       4  4c 9f 40 42 = 48.2 C
+TC30   flt       4  20 6d 41 42 = 48.4 C
+TC31   flt       4  ae db 47 42 = 50.0 C
+TC32   flt       4  9e f7 42 42 = 48.7 C
+TC33   flt       4  fa 91 43 42 = 48.9 C
+TCDX   flt       4  13 cd 49 42 = 50.5 C
+TCHP   flt       4  cc c2 20 42 = 40.2 C
+TCMb   flt       4  32 bb 6f 42 = 59.9 C
+TCMz   flt       4  2b c7 85 42 = 66.9 C
+TD00   flt       4  52 5d f6 41 = 30.8 C
+TD01   flt       4  3f 5c f6 41 = 30.8 C
+TD02   flt       4  d9 73 f5 41 = 30.7 C
+TD03   flt       4  e2 6e f3 41 = 30.4 C
+TD04   flt       4  e4 72 f1 41 = 30.2 C
+TD10   flt       4  4e 35 fa 41 = 31.3 C
+TD11   flt       4  8d 35 00 42 = 32.1 C
+TD12   flt       4  0a 12 f7 41 = 30.9 C
+TD13   flt       4  4a f0 fc 41 = 31.6 C
+TD14   flt       4  48 1c f6 41 = 30.8 C
+TD20   flt       4  10 72 01 42 = 32.4 C
+TD21   flt       4  ff a4 0d 42 = 35.4 C
+TD22   flt       4  2b f8 04 42 = 33.2 C
+TD23   flt       4  e0 bc 11 42 = 36.4 C
+TD24   flt       4  4e e7 00 42 = 32.2 C
+TDBP   flt       4  00 80 0b 42 = 34.9 C
+TDEL   flt       4  00 c0 0e 42 = 35.7 C
+TDER   flt       4  00 00 0d 42 = 35.2 C
+TDTC   flt       4  00 40 12 42 = 36.6 C
+TDTP   flt       4  00 00 10 42 = 36.0 C
+TDVx   flt       4  e0 bc 11 42 = 36.4 C
+TDeL   flt       4  00 c0 09 42 = 34.4 C
+TDeR   flt       4  00 c0 07 42 = 33.9 C
+TG0B   ioft      8  00 00 21 00 00 00 00 00 = 33.0 C
+TG0C   ioft      8  00 00 20 00 00 00 00 00 = 32.0 C
+TG0H   ioft      8  00 00 21 00 00 00 00 00 = 33.0 C
+TG0V   ioft      8  00 00 21 00 00 00 00 00 = 33.0 C
+TG1B   ioft      8  00 00 21 00 00 00 00 00 = 33.0 C
+TG2B   ioft      8  99 99 20 00 00 00 00 00 = 32.6 C
+TH0a   flt       4  00 f4 16 42 = 37.7 C
+TH0b   flt       4  00 44 17 42 = 37.8 C
+TH0x   flt       4  00 b8 16 42 = 37.7 C
+TH1a   flt       4  00 00 00 00
+TH1b   flt       4  00 00 00 00
+TMVR   flt       4  a0 04 1e 42 = 39.5 C
+TPD0   flt       4  64 e5 2a 42 = 42.7 C
+TPD1   flt       4  74 8a 2a 42 = 42.6 C
+TPD2   flt       4  84 2f 2a 42 = 42.5 C
+TPD3   flt       4  3f 9b 2b 42 = 42.9 C
+TPD4   flt       4  0c ac 2c 42 = 43.2 C
+TPD5   flt       4  84 2f 2a 42 = 42.5 C
+TPD6   flt       4  50 40 2b 42 = 42.8 C
+TPD7   flt       4  50 40 2b 42 = 42.8 C
+TPD8   flt       4  74 8a 2a 42 = 42.6 C
+TPD9   flt       4  74 8a 2a 42 = 42.6 C
+TPDX   flt       4  0c ac 2c 42 = 43.2 C
+TPDa   flt       4  64 e5 2a 42 = 42.7 C
+TPDb   flt       4  50 40 2b 42 = 42.8 C
+TPDc   flt       4  3f 9b 2b 42 = 42.9 C
+TPDd   flt       4  3f 9b 2b 42 = 42.9 C
+TPDe   flt       4  64 e5 2a 42 = 42.7 C
+TPDf   flt       4  a8 79 29 42 = 42.4 C
+TPDg   flt       4  98 d4 29 42 = 42.5 C
+TPDh   flt       4  98 d4 29 42 = 42.5 C
+TPDi   flt       4  50 40 2b 42 = 42.8 C
+TPDj   flt       4  50 40 2b 42 = 42.8 C
+TPMP   flt       4  5c c8 24 42 = 41.2 C
+TPSP   flt       4  68 a1 2a 42 = 42.7 C
+TPVD   flt       4  3f 91 35 42 = 45.4 C
+TR0Z   ioft      8  9a d9 33 00 00 00 00 00 = 51.9 C
+TR1d   ioft      8  38 7d 2c 00 00 00 00 00 = 44.5 C
+TR2d   ioft      8  b3 30 2b 00 00 00 00 00 = 43.2 C
+TRD0   flt       4  cc 10 33 42 = 44.8 C
+TRD1   flt       4  5c 39 30 42 = 44.1 C
+TRD2   flt       4  48 94 30 42 = 44.1 C
+TRD3   flt       4  6c de 2f 42 = 44.0 C
+TRD4   flt       4  f0 5a 32 42 = 44.6 C
+TRD5   flt       4  6c de 2f 42 = 44.0 C
+TRD6   flt       4  6c de 2f 42 = 44.0 C
+TRD7   flt       4  14 a5 31 42 = 44.4 C
+TRD8   flt       4  6c de 2f 42 = 44.0 C
+TRD9   flt       4  6c de 2f 42 = 44.0 C
+TRDX   flt       4  cc 10 33 42 = 44.8 C
+TRDa   flt       4  7c 83 2f 42 = 43.9 C
+TRDb   flt       4  90 28 2f 42 = 43.8 C
+TRDc   flt       4  6c de 2f 42 = 44.0 C
+TRDd   flt       4  90 28 2f 42 = 43.8 C
+TRDe   flt       4  5c 39 30 42 = 44.1 C
+TRDf   flt       4  c4 17 2e 42 = 43.5 C
+TRDg   flt       4  7c 83 2f 42 = 43.9 C
+TRDh   flt       4  a0 cd 2e 42 = 43.7 C
+TRDi   flt       4  00 00 32 42 = 44.5 C
+TRDj   flt       4  38 ef 30 42 = 44.2 C
+TS0P   flt       4  30 64 28 42 = 42.1 C
+TSVR   flt       4  88 ac 28 42 = 42.2 C
+TSWR   flt       4  cc 42 26 42 = 41.6 C
+TSXR   flt       4  38 bd 2a 42 = 42.7 C
+TVA0   flt       4  70 e4 e0 41 = 28.1 C
+TVD0   flt       4  32 bb 6f 42 = 59.9 C
+TVMD   flt       4  00 00 00 00
+TVS0   flt       4  58 d9 15 42 = 37.5 C
+TVS1   flt       4  a2 58 10 42 = 36.1 C
+TVS2   flt       4  08 4d 0e 42 = 35.6 C
+TVSx   flt       4  58 d9 15 42 = 37.5 C
+TVV0   flt       4  bf dc 47 42 = 50.0 C
+TW0P   flt       4  88 2c 29 42 = 42.3 C
+Ta00   flt       4  00 00 00 00
+Ta01   flt       4  00 00 00 00
+Ta02   flt       4  00 00 00 00
+Ta04   flt       4  00 00 00 00
+Ta05   flt       4  d9 ce 07 41 = 8.5 C
+Ta06   flt       4  04 56 2e 41 = 10.9 C
+TaLP   flt       4  cc c2 25 42 = 41.4 C
+TaLT   flt       4  a0 04 1c 42 = 39.0 C
+TaLW   flt       4  fc e3 06 42 = 33.7 C
+TaRF   flt       4  9c de 27 42 = 42.0 C
+TaRT   flt       4  7c 4e 00 42 = 32.1 C
+TaRW   flt       4  00 b9 fd 41 = 31.7 C
+TaTP   flt       4  b4 10 2f 42 = 43.8 C
+Td00   flt       4  9c 2b 33 42 = 44.8 C
+Td01   flt       4  9c 2b 33 42 = 44.8 C
+Td02   flt       4  00 00 37 42 = 45.8 C
+Td04   flt       4  37 df 3c 42 = 47.2 C
+Td05   flt       4  37 df 3c 42 = 47.2 C
+Td06   flt       4  00 10 43 42 = 48.8 C
+Td08   flt       4  c4 77 38 42 = 46.1 C
+Td09   flt       4  c4 77 38 42 = 46.1 C
+Td0A   flt       4  00 10 3d 42 = 47.3 C
+Td0C   flt       4  32 44 34 42 = 45.1 C
+Td0D   flt       4  32 44 34 42 = 45.1 C
+Td0E   flt       4  00 40 38 42 = 46.1 C
+Te00   flt       4  e7 de 3c 42 = 47.2 C
+Te01   flt       4  7e 4d 72 42 = 60.6 C
+Te02   flt       4  71 95 85 42 = 66.8 C
+Tg04   flt       4  dd 16 2f 42 = 43.8 C
+Tg05   flt       4  aa e3 53 42 = 53.0 C
+Tg0C   flt       4  ae 00 3c 42 = 47.0 C
+Tg0D   flt       4  7b cd 60 42 = 56.2 C
+Th00   flt       4  9d 2f 3a 42 = 46.5 C
+Th01   flt       4  9b 84 57 42 = 53.9 C
+Th02   flt       4  00 a0 64 42 = 57.2 C
+Th04   flt       4  a7 67 37 42 = 45.9 C
+Th05   flt       4  a7 67 37 42 = 45.9 C
+Th06   flt       4  00 c0 40 42 = 48.2 C
+Th08   flt       4  9a fe 32 42 = 44.7 C
+Th09   flt       4  9a fe 32 42 = 44.7 C
+Th0A   flt       4  00 30 34 42 = 45.0 C
+Tm00   flt       4  25 17 36 42 = 45.5 C
+Tm01   flt       4  25 17 36 42 = 45.5 C
+Tm02   flt       4  00 b0 3a 42 = 46.7 C
+Tm04   flt       4  db 58 3f 42 = 47.8 C
+Tm05   flt       4  db 58 3f 42 = 47.8 C
+Tm06   flt       4  00 20 44 42 = 49.0 C
+Tp00   flt       4  0d 41 4d 42 = 51.3 C
+Tp01   flt       4  f4 3c 71 42 = 60.3 C
+Tp02   flt       4  2b a7 87 42 = 67.8 C
+Tp04   flt       4  36 13 46 42 = 49.5 C
+Tp05   flt       4  a9 fb 69 42 = 58.5 C
+Tp06   flt       4  50 5d 85 42 = 66.7 C
+Tp08   flt       4  ad 25 44 42 = 49.0 C
+Tp09   flt       4  26 0f 68 42 = 58.0 C
+Tp0A   flt       4  27 f1 79 42 = 62.5 C
+Tp0C   flt       4  55 13 3d 42 = 47.3 C
+Tp0D   flt       4  ee ac 61 42 = 56.4 C
+Tp0E   flt       4  0a 2f 82 42 = 65.1 C
+Tp0G   flt       4  0a b7 38 42 = 46.2 C
+Tp0H   flt       4  7d 1f 5d 42 = 55.3 C
+Tp0I   flt       4  bc f4 72 42 = 60.7 C
+Tp0K   flt       4  f0 73 39 42 = 46.4 C
+Tp0L   flt       4  1f d1 5c 42 = 55.2 C
+Tp0M   flt       4  87 d6 80 42 = 64.4 C
+Tp0O   flt       4  a0 b9 36 42 = 45.7 C
+Tp0P   flt       4  1b 4e 5a 42 = 54.6 C
+Tp0Q   flt       4  cb b1 82 42 = 65.3 C
+Tp0S   flt       4  1d 66 39 42 = 46.3 C
+Tp0T   flt       4  94 a4 5d 42 = 55.4 C
+Tp0U   flt       4  96 33 71 42 = 60.3 C
+Tp0W   flt       4  16 58 3b 42 = 46.8 C
+Tp0X   flt       4  6e 11 5f 42 = 55.8 C
+Tp0Y   flt       4  d3 ed 7e 42 = 63.7 C
+Tp0a   flt       4  91 56 39 42 = 46.3 C
+Tp0b   flt       4  4e 4b 5d 42 = 55.3 C
+Tp0c   flt       4  cf 37 73 42 = 60.8 C
+Ts00   flt       4  e2 73 3b 42 = 46.9 C
+Ts01   flt       4  e2 73 3b 42 = 46.9 C
+Ts02   flt       4  00 c0 44 42 = 49.2 C
+Ts04   flt       4  0a 70 3a 42 = 46.6 C
+Ts05   flt       4  0a 70 3a 42 = 46.6 C
+Ts06   flt       4  00 10 44 42 = 49.0 C
+Ts0P   flt       4  00 f8 ff 41 = 32.0 C
+Ts1P   flt       4  00 f8 ef 41 = 30.0 C
+Tz11   flt       4  00 00 00 00
+Tz12   flt       4  00 00 00 00
+Tz13   flt       4  00 00 00 00
+Tz14   flt       4  00 00 00 00
+Tz15   flt       4  00 00 00 00
+Tz16   flt       4  00 00 00 00
+Tz17   flt       4  00 00 00 00
+Tz18   flt       4  00 00 00 00
+Tz1j   flt       4  00 00 00 00
+U1B0   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+U1D0   ui16      2  00 00
+U1N0   ui32      4  00 00 00 00
+U1R0   ui16      2  00 00
+U1S0   ui8       1  00 = 0
+U1bs   ui8       1  00 = 0
+U2B0   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+U2D0   ui16      2  00 00
+U2N0   ui32      4  00 00 00 00
+U2R0   ui16      2  00 00
+U2S0   ui8       1  00 = 0
+U2bs   ui8       1  00 = 0
+U3B0   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+U3D0   ui16      2  00 00
+U3N0   ui32      4  00 00 00 00
+U3R0   ui16      2  00 00
+U3S0   ui8       1  00 = 0
+U3bs   ui8       1  00 = 0
+U4B0   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+U4D0   ui16      2  00 00
+U4N0   ui32      4  00 00 00 00
+U4R0   ui16      2  00 00
+U4S0   ui8       1  00 = 0
+U4bs   ui8       1  00 = 0
+UB0C   ui8       1  00 = 0
+UB0T   ui64      8  00 00 00 00 00 00 00 00
+UBAC   si16      2  00 00
+UBAT   si16      2  00 00
+UBAV   ui16      2  00 00
+UBCR   hex_      1  01 = 1
+UBD0   ui16      2  00 00
+UBDD   si16      2  00 00
+UBFC   ui16      2  00 00
+UBHR   hex_      1  00 = 0
+UBID   si16      2  00 00
+UBIS   si16      2  00 00
+UBNC   ui16      2  00 00
+UBPC   si16      2  00 00
+UBPF   ui16      2  00 00
+UBPI   si16      2  00 00
+UBPN   ui16      2  00 00
+UBPR   si16      2  00 00
+UBPV   ui16      2  00 00
+UBRM   si16      2  00 00
+UBRS   si16      2  00 00
+UBSS   ui16      2  00 00
+UBUI   ui8       1  00 = 0
+UCFG   hex_      2  04 14
+UPOC   ui16      2  00 00
+UPOF   hex_      1  00 = 0
+UPOR   flag      1  00 = 0
+UPOS   ui8       1  00 = 0
+UPOT   ui8       1  00 = 0
+VBUS   ui32      4  01 00 00 00
+VC10   flt       4  00 48 6e 3f
+VC11   flt       4  00 8d 88 3f
+VC12   flt       4  00 76 73 3f
+VC13   flt       4  80 68 88 3f
+VC20   flt       4  00 00 00 00
+VC21   flt       4  00 bf 4b 3f
+VC22   flt       4  00 b0 1b 3f
+VC23   flt       4  00 09 4c 3f
+VC30   flt       4  00 00 92 3a
+VC31   flt       4  00 00 92 3a
+VC32   flt       4  00 54 39 3f
+VC33   flt       4  00 1d 1b 3f
+VD0R   flt       4  06 c0 9f 41
+VDMA   flt       4  3c 89 73 40
+VDMM   flt       4  2b 7b 72 40
+VMVC   flt       4  20 19 73 40
+VP0R   flt       4  37 5f 40 41
+VP0b   flt       4  00 dd 51 3f
+VP0s   flt       4  80 35 9d 3f
+VP1b   flt       4  00 74 47 3f
+VP1l   flt       4  00 c5 53 40
+VP2b   flt       4  00 3e 6d 3f
+VP2l   flt       4  00 96 e5 3f
+VP3b   flt       4  00 86 e6 3f
+VP3l   flt       4  00 00 00 00
+VP4b   flt       4  00 78 86 3f
+VP5b   flt       4  00 21 1f 3f
+VP5l   flt       4  00 e4 4c 3f
+VP6b   flt       4  00 75 90 3f
+VP7b   flt       4  00 65 51 3f
+VP8b   flt       4  80 95 9d 3f
+VP9b   flt       4  00 6c 4f 3f
+VPab   flt       4  00 11 14 3f
+VR0b   flt       4  00 55 5b 3f
+VR0l   flt       4  00 b4 40 3f
+VR0s   flt       4  80 e7 bf 3f
+VR1b   flt       4  00 31 15 3f
+VR1l   flt       4  00 00 00 00
+VR2b   flt       4  00 d6 68 3f
+VR3b   flt       4  00 46 e5 3f
+VR4b   flt       4  00 fc 86 3f
+VR5b   flt       4  00 42 20 3f
+VR6b   flt       4  00 ad 5d 3f
+VR8b   flt       4  80 d1 9d 3f
+VR9b   flt       4  00 81 90 3f
+VRab   flt       4  00 52 28 3f
+VSVR   flt       4  46 f7 e6 3f
+Vb0f   flt       4  dd 61 40 41
+Vb1f   flt       4  69 49 40 41
+WKTP   ui8       1  00 = 0
+YBj0   hex_    120  
+YBk0   ui32      4  00 00 00 00
+YBl0   ui32      4  00 00 00 00
+YBm0   hex_     12  ff ff ff ff 00 00 00 00 00 00 00 00
+YBn0   ui32      4  00 00 00 00
+YBo0   ui32      4  ff ff ff ff
+YBv0   ui32      4  01 00 00 00
+YCa0   hex_    100  
+YCa1   hex_    100  
+YCa2   hex_    100  
+YCa3   hex_    100  
+YCa4   hex_    100  
+YCb0   hex_     20  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+YCc0   hex_      8  00 00 00 00 00 00 00 00
+YCd0   ui32      4  06 00 00 00
+YCe0   ui32      4  04 00 00 00
+YCf0   ui8       1  01 = 1
+YCg0   hex_      9  00 00 00 00 00 00 00 00 00
+YUv0   ui64      8  00 00 00 00 00 00 00 00
+YUx0   ui8       1  fc = 252
+YVa0   ui8       1  00 = 0
+aDC!   ui32      4  00 00 00 00
+aDC#   ui32      4  a2 00 00 00
+aDC?   ui32      4  00 00 00 00
+aDCR   ioft      8  00 00 00 00 00 00 00 00
+aP00   ui32      4  04 00 00 00
+aP01   ui32      4  0d 00 00 00
+aP02   ui32      4  58 08 00 00
+aP58   ui32      4  00 00 00 00
+aP59   ui32      4  00 00 00 00
+aP5a   ui32      4  e4 0c 00 00
+aP5b   ui32      4  e8 0c 00 00
+aP5c   ui32      4  e8 0c 00 00
+aP5d   ui32      4  e8 0c 00 00
+aP5e   ui32      4  e3 0c 00 00
+aP70   ui32      4  e3 09 00 00
+aP71   ui32      4  c9 05 00 00
+aP72   ui32      4  47 0b 00 00
+aP73   ui32      4  1c 00 00 00
+aP74   ui32      4  08 0c 00 00
+aP75   ui32      4  c1 08 00 00
+aP76   ui32      4  1f 0d 00 00
+aP77   ui32      4  a6 08 00 00
+aP78   ui32      4  28 06 00 00
+aP79   ui32      4  cf 0c 00 00
+aP7a   ui32      4  4b 00 00 00
+aP7b   ui32      4  00 00 00 00
+aP7c   ui32      4  02 00 00 00
+aP7d   ui32      4  19 00 00 00
+aP7e   ui32      4  00 00 00 00
+aP7f   ui32      4  00 00 00 00
+aP80   ui32      4  1d 00 00 00
+aPMX   ui8       1  00 = 0
+bHLD   ui32      4  00 00 00 00
+bPHD   flag      1  00 = 0
+bRIN   ui32      4  00 00 00 00
+bVDN   ui32      4  00 00 00 00
+bVUP   ui32      4  00 00 00 00
+bca0   si32      4  85 fb ff ff
+bcb0   ui8       1  00 = 0
+bcc0   ui8       1  00 = 0
+bcd0   flag      1  00 = 0
+bce0   si32      4  06 fd ff ff
+bce1   si32      4  1a fe ff ff
+bce4   si32      4  89 fd ff ff
+bce5   si32      4  97 fd ff ff
+bce8   si32      4  dd fd ff ff
+bce9   si32      4  43 fd ff ff
+bck0   ui8       1  00 = 0
+bcl0   ui32      4  ff ff 00 00
+bdF0   hex_      4  92 51 00 00
+bdF8   hex_      4  92 51 00 00
+bdFF   hex_      4  92 51 00 00
+bdJ0   ui16      2  43 00
+bdJ8   ui16      2  40 00
+bdJF   ui16      2  44 00
+bdj0   ????      0  
+bfA0   hex_    120  
+bfB0   ui16      2  f6 0b
+bfC0   ui16      2  f2 0b
+bfD0   ui32      4  04 10 00 00
+bfE0   ui32      4  10 0e 00 00
+bfF0   ui8       1  00 = 0
+bfG0   hex_      3  00 00 00
+bfH0   hex_      8  00 00 00 00 00 00 00 00
+bfI0   si8       1  4d = 77
+bfJ0   ui8       1  01 = 1
+bfK0   ui8       1  01 = 1
+bfL0   flag      1  00 = 0
+bfv0   hex_      4  02 00 00 00
+bfx0   ui32      4  00 00 00 00
+bmA0   hex_    112  
+bmA8   hex_    112  
+bmAF   hex_    112  
+bmF0   ui8       1  04 = 4
+bmG0   ui16      2  b3 10
+bmH0   ui16      2  b3 10
+bmI0   ui16      2  b3 10
+bmJ0   ui16      2  ef 10
+bmK0   ui16      2  b3 10
+bmL0   ui64      8  00 00 00 00 00 00 00 00
+bmN0   ui8       1  00 = 0
+bmQ0   hex_     12  64 00 96 00 c8 00 fa 00 e8 03 ff ff
+bmR0   hex_     12  00 00 00 00 00 00 00 00 00 00 00 00
+bmS0   hex_     12  ef 10 e5 10 d1 10 bd 10 b3 10 81 10
+bmT0   hex_     56  
+bma0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmb0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmc0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmd0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bme0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmf0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmg0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmh0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmi0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmj0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmk0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bml0   ????      0  
+bmm0   hex_     25  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+bmn0   flag      1  00 = 0
+bnN0   flt       4  00 00 80 3f
+bpx0   hex_      1  00 = 0
+btq0   hex_      1  56 = 86
+bvu0   ui16      2  00 00
+bvv0   hex_      4  92 51 00 00
+bvw0   ui16      2  01 01
+bvx0   ui16      2  44 00
+bvy0   ui16      2  2a 00
+bvz0   ui16      2  30 00
+bwA0   ui16      2  3b 00
+bwB0   ui16      2  2e 00
+bwC0   ui16      2  39 00
+bwD0   ui16      2  3e 00
+bwE0   ui16      2  43 00
+bwF0   ui16      2  47 00
+bwG0   ui16      2  49 00
+bwH0   ui16      2  5b 00
+bwI0   ui16      2  69 00
+bwJ0   ui16      2  03 01
+bwK0   ui16      2  cc 01
+bwL0   hex_      2  c0 00
+bwM0   si64      8  b1 b4 fe ff ff ff ff ff
+bwN0   ui64      8  08 05 00 00 00 00 00 00
+bwO0   ui16      2  f6 12
+bwP0   ui16      2  f6 12
+bwQ0   ui16      2  00 00
+ceD1   flt       4  00 00 00 00
+ceF0   flt       4  00 00 00 00
+ceF1   flt       4  00 00 00 00
+ceF2   flt       4  00 00 00 00
+ceFa   flt       4  00 00 00 00
+ceFn   flt       4  00 00 00 00
+ceFv   flt       4  00 00 00 00
+ceNn   flt       4  00 00 00 00
+ceP0   flt       4  00 00 00 00
+ceP1   flt       4  00 00 00 00
+ceP2   flt       4  00 00 00 00
+cePB   flt       4  00 00 00 00
+cePC   flt       4  00 00 00 00
+cePD   flt       4  00 00 00 00
+cePa   flt       4  00 00 00 00
+cePv   flt       4  00 00 00 00
+cePw   flt       4  00 00 00 00
+cePz   flt       4  00 00 00 00
+ceU0   flt       4  4e 06 85 42
+ceU1   flt       4  ac 4c e1 40
+ceU2   flt       4  00 00 00 00
+ceUR   flt       4  00 00 00 00
+cef0   flt       4  00 00 00 00
+cef1   flt       4  00 00 00 00
+cef2   flt       4  00 00 00 00
+cmF0   flt       4  00 d0 10 45
+cmF1   flt       4  00 d0 10 45
+cmF2   flt       4  00 00 00 00
+cmFa   flt       4  00 00 00 00
+cmFs   flt       4  00 00 c8 42
+cmFv   flt       4  00 00 00 00
+cmPC   flt       4  00 00 e0 40
+cmPN   flt       4  00 00 00 00
+cmPS   flt       4  00 00 c8 42
+cmPz   flt       4  00 00 00 00
+cmTa   flt       4  00 00 c8 42
+cmTb   flt       4  00 00 c8 42
+cmTl   flt       4  00 00 c8 42
+cmTv   flt       4  00 00 c8 42
+csF0   flt       4  00 00 00 00
+csF1   flt       4  00 00 00 00
+csF2   flt       4  00 00 00 00
+csFa   flt       4  00 00 00 00
+csFn   flt       4  00 00 00 00
+csFv   flt       4  00 00 00 00
+csP0   flt       4  00 00 00 00
+csP1   flt       4  00 00 00 00
+csP2   flt       4  00 00 00 00
+csPB   flt       4  00 00 00 00
+csPC   flt       4  00 00 00 00
+csPD   flt       4  00 00 00 00
+csPa   flt       4  00 00 00 00
+csPv   flt       4  00 00 00 00
+csPw   flt       4  00 00 00 00
+csU0   flt       4  00 00 00 00
+csU1   flt       4  00 00 00 00
+csU2   flt       4  00 00 00 00
+csf0   flt       4  00 00 00 00
+csf1   flt       4  00 00 00 00
+csf2   flt       4  00 00 00 00
+fSX3   flt       4  00 00 00 00
+fc0S   si32      4  00 00 00 00
+fc0T   flt       4  00 d0 10 45
+fcB0   flt       4  d4 15 a1 42
+fcMN   flt       4  00 d0 10 45
+fcMX   flt       4  00 98 b4 45
+fcdx   flt       4  75 13 df 41
+fchx   flt       4  00 00 00 00
+fclx   flt       4  75 13 df 41
+fcof   flt       4  00 00 16 43
+fdBA   flt       4  7f 4e 84 41
+fdS0   flt       4  3e 33 d2 40
+fdS1   flt       4  dd 39 a3 40
+fdS2   flt       4  dd 81 a5 40
+fdS3   flt       4  39 3f a5 3e
+fiB0   flt       4  12 d0 37 3d
+fiiz   flt       4  4a bd b9 3f
+fpC0   flt       4  d9 a1 02 41
+fpS0   flt       4  63 ba 0c 41
+fpS1   flt       4  a9 b4 00 41
+ftA0   flt       4  d9 ce 07 41
+ftB0   flt       4  a9 f8 04 42
+ftE0   flt       4  7e 4d 72 42
+ftF0   flt       4  7f d1 25 42
+ftF1   flt       4  1a e5 2e 42
+ftF2   flt       4  a5 fe 19 42
+ftF3   flt       4  64 de 2d 42
+ftF4   flt       4  e5 6f 02 42
+ftG0   flt       4  10 4a 54 42
+ftG1   flt       4  e1 33 61 42
+ftH0   flt       4  d5 50 17 42
+ftLx   flt       4  2a 15 1a 42
+ftN0   flt       4  4c 84 16 42
+ftP0   flt       4  f4 3c 71 42
+ftP1   flt       4  a9 fb 69 42
+ftP2   flt       4  26 0f 68 42
+ftP3   flt       4  ee ac 61 42
+ftP4   flt       4  7d 1f 5d 42
+ftP5   flt       4  1f d1 5c 42
+ftP6   flt       4  1b 4e 5a 42
+ftP7   flt       4  94 a4 5d 42
+ftP8   flt       4  6e 11 5f 42
+ftP9   flt       4  4e 4b 5d 42
+ftS0   flt       4  77 71 71 42
+ftS1   flt       4  50 a4 71 42
+ftSa   flt       4  77 71 71 42
+ftV0   flt       4  79 c6 1e 42
+ftV1   flt       4  c3 08 43 42
+ftV2   flt       4  f9 fd 47 42
+ftV3   flt       4  aa 6f 43 42
+ftV4   flt       4  7e 73 46 42
+ftV5   flt       4  53 8a 3d 42
+ftV6   flt       4  b9 b1 41 42
+ftV7   flt       4  e0 8c 3f 42
+ftV8   flt       4  4c 9f 40 42
+ftV9   flt       4  20 6d 41 42
+ftVV   flt       4  de d3 6d 42
+ftVa   flt       4  ae db 47 42
+ftVb   flt       4  9e f7 42 42
+ftVc   flt       4  fa 91 43 42
+ftVv   flt       4  de d3 6d 42
+ftlx   flt       4  38 1c 12 42
+ftm0   flt       4  42 b9 2c 42
+ftt0   flt       4  81 74 00 42
+ftt1   flt       4  cd 09 f0 41
+ftvx   flt       4  1e 43 4e 42
+fuF0   flt       4  00 00 7f 43
+fuF1   flt       4  00 00 7f 43
+fuF2   flt       4  00 00 7f 43
+fuP0   flt       4  00 00 3c 42
+fuP1   flt       4  00 00 34 42
+fuP2   flt       4  00 00 34 42
+gP01   ui32      4  00 00 00 00
+gP02   ui32      4  00 00 00 00
+gP03   ui32      4  00 00 00 00
+gP04   ui32      4  00 00 00 00
+gP05   ui32      4  00 00 00 00
+gP06   ui32      4  00 00 00 00
+gP07   ui32      4  00 00 00 00
+gP08   ui32      4  00 00 00 00
+gP09   ui32      4  00 00 00 00
+gP0a   ui32      4  00 00 00 00
+gP0b   ui32      4  00 00 00 00
+gP0c   ui32      4  00 00 00 00
+gP0d   ui32      4  00 00 00 00
+gP0e   ui32      4  00 00 00 00
+gP0f   ui32      4  00 00 00 00
+gP10   ui32      4  00 00 00 00
+gP11   ui32      4  00 00 00 00
+gP12   ui32      4  00 00 00 00
+gP13   ui32      4  00 00 00 00
+gP14   ui32      4  00 00 00 00
+gP15   ui32      4  00 00 00 00
+gP16   ui32      4  00 00 00 00
+gP17   ui32      4  00 00 00 00
+gP18   ui32      4  00 00 00 00
+gP19   ui32      4  00 00 00 00
+gP1a   ui32      4  00 00 00 00
+gp03   ui32      4  00 00 00 00
+iaFh   flt       4  00 e8 af 45
+iaFl   flt       4  00 30 1a 45
+isD1   flt       4  00 00 00 00
+isF0   flt       4  00 00 00 00
+isF1   flt       4  00 00 00 00
+isF2   flt       4  00 00 00 00
+isFa   flt       4  00 00 00 00
+isFn   flt       4  00 00 00 00
+isFv   flt       4  00 00 00 00
+isNn   flt       4  00 00 00 00
+isP0   flt       4  00 00 00 00
+isP1   flt       4  00 00 00 00
+isP2   flt       4  00 00 00 00
+isPB   flt       4  00 00 00 00
+isPC   flt       4  00 00 00 00
+isPD   flt       4  00 00 00 00
+isPa   flt       4  00 00 00 00
+isPv   flt       4  00 00 00 00
+isPw   flt       4  00 00 00 00
+isPz   flt       4  00 00 00 00
+isU0   flt       4  44 31 95 42
+isU1   flt       4  66 80 0e 42
+isU2   flt       4  00 00 00 00
+isUR   flt       4  00 00 00 00
+isf0   flt       4  00 00 00 00
+isf1   flt       4  00 00 00 00
+isf2   flt       4  00 00 00 00
+mTPL   si32      4  00 00 00 00
+mUTL   flt       4  00 00 00 00
+maF0   si32      4  00 00 00 00
+maF1   si32      4  00 00 00 00
+maF2   si32      4  00 00 00 00
+maFa   si32      4  00 00 00 00
+maFn   si32      4  00 00 00 00
+maFv   si32      4  00 00 00 00
+maP0   si32      4  00 00 00 00
+maP1   si32      4  00 00 00 00
+maP2   si32      4  00 00 00 00
+maPB   si32      4  00 00 00 00
+maPC   si32      4  00 00 00 00
+maPD   si32      4  00 00 00 00
+maPa   si32      4  00 00 00 00
+maPv   si32      4  00 00 00 00
+maPw   si32      4  00 00 00 00
+maU0   si32      4  00 00 00 00
+maU1   si32      4  00 00 00 00
+maU2   si32      4  00 00 00 00
+maf0   si32      4  00 00 00 00
+maf1   si32      4  00 00 00 00
+maf2   si32      4  00 00 00 00
+mlD1   flt       4  00 00 c8 42
+mlF0   flt       4  00 00 00 00
+mlF1   flt       4  00 00 00 00
+mlF2   flt       4  00 00 00 00
+mlFa   flt       4  00 00 00 00
+mlFn   flt       4  00 00 00 00
+mlFv   flt       4  00 00 00 00
+mlP0   flt       4  00 00 c8 42
+mlP1   flt       4  00 00 c8 42
+mlP2   flt       4  00 00 c8 42
+mlPB   flt       4  00 00 c8 42
+mlPC   flt       4  00 00 70 41
+mlPD   flt       4  00 00 c8 42
+mlPa   flt       4  00 00 c8 42
+mlPv   flt       4  00 00 c8 42
+mlPw   flt       4  00 00 c8 42
+mlT0   flt       4  00 00 c8 42
+mlT1   flt       4  00 00 c8 42
+mlT2   flt       4  00 00 c8 42
+mlTh   flt       4  00 00 c8 42
+mlTp   flt       4  ce 38 8d 42
+mlU0   flt       4  64 f3 05 42
+mlU1   flt       4  35 eb b9 42
+mlU2   flt       4  00 00 c8 42
+mlUR   flt       4  00 00 c8 42
+mlf0   flt       4  00 00 00 00
+mlf1   flt       4  00 00 00 00
+mlf2   flt       4  00 00 00 00
+mlt0   flt       4  00 00 c8 42
+mlt1   flt       4  00 00 c8 42
+mlt2   flt       4  00 00 c8 42
+mmLA   si32      4  00 00 00 00
+mmPN   si32      4  00 00 00 00
+mxT0   flt       4  00 00 c8 42
+mxTs   flt       4  00 00 c8 42
+nn00   flt       4  00 00 00 00
+oF00   si32      4  01 00 00 00
+oF01   si32      4  05 00 00 00
+oKI4   flt       4  46 7e 7d 3a
+oKI5   flt       4  46 7e 7d 3a
+oKI6   flt       4  bc 74 13 3c
+oKI7   flt       4  bc 74 13 3c
+oKP4   flt       4  07 cf 04 3c
+oKP5   flt       4  07 cf 04 3c
+oKP6   flt       4  42 60 e5 3b
+oKP7   flt       4  42 60 e5 3b
+ocer   flt       4  00 00 c8 42
+ocex   flt       4  00 00 98 42
+ocey   flt       4  00 00 98 42
+ocez   flt       4  00 00 98 42
+of00   si32      4  05 00 00 00
+of01   si32      4  14 00 00 00
+of10   si32      4  05 00 00 00
+of11   si32      4  1e 00 00 00
+of12   si32      4  01 00 00 00
+of13   si32      4  01 00 00 00
+of20   si32      4  2c 01 00 00
+of21   si32      4  14 00 00 00
+ofc0   flt       4  00 00 00 00
+ofc1   flt       4  00 00 c8 42
+ofc2   flt       4  00 00 48 43
+ofc3   flt       4  00 00 00 00
+ofc4   flt       4  00 00 c8 42
+ofc5   flt       4  00 00 48 43
+ofl0   flt       4  00 00 00 00
+ofl1   flt       4  00 00 c8 42
+ofl2   flt       4  00 00 48 43
+ofl3   flt       4  00 00 00 00
+ofl4   flt       4  00 00 c8 42
+ofl5   flt       4  00 00 48 43
+oisr   flt       4  00 00 c8 42
+oisu   flt       4  00 00 98 42
+oisy   flt       4  00 00 98 42
+oisz   flt       4  00 00 98 42
+okeA   flt       4  00 00 00 00
+okeV   flt       4  00 00 20 41
+oki0   flt       4  7c f2 b0 3c
+oki1   flt       4  7c f2 b0 3c
+oki2   flt       4  7c f2 b0 3c
+oki3   flt       4  2d b2 1d 3d
+oki4   flt       4  2d b2 1d 3d
+oki5   flt       4  2d b2 1d 3d
+oki6   flt       4  2d b2 1d 3d
+oki7   flt       4  2d b2 1d 3d
+oki8   flt       4  2d b2 1d 3d
+okiA   flt       4  cd cc 4c 3e
+okiN   flt       4  cd cc 4c 3d
+okiV   flt       4  0a d7 a3 3c
+okia   flt       4  bc 74 13 3d
+okib   flt       4  8f c2 75 3d
+okic   flt       4  cd cc cc 3d
+okid   flt       4  00 00 00 40
+okif   flt       4  cd cc cc 3d
+okin   flt       4  8f c2 75 3d
+okir   flt       4  17 b7 51 3a
+okiv   flt       4  cd cc 4c 3e
+okix   flt       4  8f c2 75 3d
+okiy   flt       4  8f c2 75 3d
+okiz   flt       4  8f c2 75 3d
+okp0   flt       4  58 39 ac 40
+okp1   flt       4  58 39 ac 40
+okp2   flt       4  58 39 ac 40
+okp3   flt       4  c3 f5 28 40
+okp4   flt       4  c3 f5 28 40
+okp5   flt       4  c3 f5 28 40
+okp6   flt       4  c3 f5 28 40
+okp7   flt       4  c3 f5 28 40
+okp8   flt       4  c3 f5 28 40
+okpA   flt       4  66 66 16 40
+okpN   flt       4  66 66 06 40
+okpV   flt       4  98 6e 22 40
+okpa   flt       4  66 66 66 40
+okpb   flt       4  00 00 40 40
+okpc   flt       4  00 00 20 41
+okpd   flt       4  00 00 a0 40
+okpf   flt       4  00 00 00 00
+okpn   flt       4  00 00 00 40
+okpr   flt       4  0a d7 a3 3c
+okpv   flt       4  00 00 20 40
+okpx   flt       4  33 33 6f 41
+okpy   flt       4  33 33 6f 41
+okpz   flt       4  33 33 6f 41
+oof0   flt       4  d9 ce 07 41
+oof1   flt       4  5e ba 55 41
+oof2   flt       4  9e ef 0f 41
+oof3   flt       4  cb a1 0f 41
+oof4   flt       4  e3 a5 0f 41
+oof5   flt       4  66 66 12 41
+oof6   flt       4  cb a1 11 41
+oof7   flt       4  bc 74 0d 41
+oof8   flt       4  ec 51 0e 41
+oof9   flt       4  db f9 10 41
+oofA   flt       4  00 00 00 00
+oofa   flt       4  60 e5 0e 41
+oofb   flt       4  f2 d2 0f 41
+oofc   flt       4  cd cc 14 41
+oofd   flt       4  cd cc 14 41
+otSC   flt       4  00 00 e0 40
+oumn   flt       4  00 00 80 40
+oumx   flt       4  00 00 f0 41
+pmDB   ui32      4  00 ff 00 00
+pmFC   hex_      2  00 00
+pmFL   hex_      2  00 00
+pmHC   ui8       1  03 = 3
+pmVC   ui32      4  00 00 00 00
+rARA   ui32      4  00 00 00 00
+rARa   ui32      4  00 00 00 00
+rASO   ui32      4  00 00 00 00
+rASo   ui32      4  00 00 00 00
+rBK0   ui32      4  00 00 00 00
+rBK1   ui32      4  00 00 00 00
+rBK2   ui32      4  00 00 00 00
+rBK3   ui32      4  00 00 00 00
+rBK4   ui32      4  00 00 00 00
+rBK5   ui32      4  00 00 00 00
+rBK6   ui32      4  00 00 00 00
+rBK7   ui32      4  00 00 00 00
+rBK8   ui32      4  00 00 00 00
+rBK9   ui32      4  00 00 00 00
+rBKa   ui32      4  00 00 00 00
+rBSW   ui32      4  00 00 00 00
+rCPU   ui32      4  00 00 00 00
+rCTL   ui32      4  00 00 00 00
+rLD0   ui32      4  00 00 00 00
+rLD1   ui32      4  00 00 00 00
+rLD2   ui32      4  00 00 00 00
+rLD3   ui32      4  00 00 00 00
+rLD4   ui32      4  00 00 00 00
+rLD5   ui32      4  00 00 00 00
+rLD6   ui32      4  00 00 00 00
+rLOW   ui32      4  00 00 00 00
+rRAM   ui32      4  00 00 00 00
+rSOC   ui32      4  00 00 00 00
+rVD2   ui32      4  1a 04 00 00
+rVDA   ui32      4  00 00 00 00
+rVDB   ui32      4  0a 03 00 00
+rVDF   ui32      4  00 00 00 00
+rWRM   ui32      4  00 00 00 00
+sEEC   ui64      8  a7 4d bd ac 04 72 ec ab
+sEOC   ui16      2  05 00
+uu00   flt       4  00 00 00 00
+uuD1   flt       4  00 00 5c 42
+uuF0   flt       4  00 00 7f 43
+uuF1   flt       4  00 00 7f 43
+uuF2   flt       4  00 00 7f 43
+uuFa   flt       4  00 00 cc 42
+uuFn   flt       4  00 00 90 42
+uuFv   flt       4  00 00 c8 42
+uuJM   flt       4  00 00 00 00
+uuLA   flt       4  00 00 00 00
+uuNn   flt       4  00 00 94 42
+uuP0   flt       4  00 00 3c 42
+uuP1   flt       4  00 00 34 42
+uuP2   flt       4  00 00 34 42
+uuPB   flt       4  00 00 5c 42
+uuPa   flt       4  00 00 48 43
+uuPv   flt       4  00 00 da 42
+uuPw   flt       4  00 00 48 43
+uuPz   flt       4  29 9c 2b 43
+uuU0   flt       4  00 00 18 42
+uuU1   flt       4  00 00 18 42
+uuU2   flt       4  00 00 18 42
+uuUR   flt       4  00 20 2d 45
+uuZ0   flt       4  00 00 00 00
+uuf0   flt       4  00 00 34 42
+uuf1   flt       4  00 00 30 42
+uuf2   flt       4  00 00 30 42
+uusn   flt       4  00 00 00 00
+voF0   flt       4  00 d0 10 45
+voP0   flt       4  00 00 c8 42
+voTS   flt       4  00 00 c8 42
+voTl   flt       4  00 00 c8 42
+voTn   flt       4  00 00 c8 42
+voTp   flt       4  ce 38 8d 42
+voTs   flt       4  00 00 c8 42
+voU0   flt       4  64 f3 05 42
+w000   si32      4  00 00 00 00
+w001   si32      4  00 00 00 00
+xDPE   flt       4  63 4b d4 40
+xLPM   flt       4  00 00 7f 43
+xMDr   flt       4  00 00 c8 42
+xPDs   flt       4  00 ff 7f 47
+xPPT   flt       4  00 00 7f 43
+xUPT   flt       4  0c 4f 4b 41
+zEAO   hex_     32  01 02 03 00 00 00 f8 41 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+zED0   hex_    120  
+zED1   hex_    120  
+zES0   hex_     16  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+zETD   hex_     96  
+zETM   hex_    120  
+zSAa   ui64      8  ab 8e 0e 00 02 00 00 00
+zSAc   ui32      4  a2 04 00 00
+zSAi   ui32      4  72 00 00 00
+zSBa   ui64      8  4e 2e ce 00 00 00 00 00
+zSBc   ui32      4  6a 02 00 00
+zSBi   si32      4  3b ae ff ff
+zSDa   si64      8  c9 d7 28 ff ff ff ff ff
+zSDc   ui32      4  39 02 00 00
+zSEi   ui64      8  c8 98 88 00 00 00 00 00
+zSEj   ui32      4  21 00 00 00
+zSEm   ch8*     32  72 6a 34 72 70 71 75 38 70 61 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+zSEs   ui32      4  93 00 00 00
+zSEw   ui64      8  73 27 97 00 00 00 00 00
+zSLa   si64      8  97 c1 f4 01 00 00 00 00
+zSLc   ui32      4  a3 04 00 00
+zSLi   si32      4  3f 52 00 00
+zSPa   ui64      8  ae c7 eb 01 00 00 00 00
+zSPc   ui32      4  a2 04 00 00
+zSPe   ui32      4  00 00 00 00
+zSPi   ui32      4  7a 00 00 00
+zSPm   ui32      4  00 4e 00 00
+zSPn   ui32      4  06 00 00 00
+zSPp   hex_    112  
+zSPq   hex_     44  
+zSPr   hex_    100  
+zSPs   si32      4  00 00 00 00
+zSPt   ui32      4  00 00 00 00
+zSPu   si64      8  00 00 00 00 00 00 00 00
+zSQ0   ui32      4  00 00 00 00
+zSR0   ui32      4  00 00 00 00
+zSS0   ui32      4  00 00 00 00
+zST0   ui8       1  00 = 0
+zSU0   si32      4  00 00 00 00
+zSV0   ui64      8  00 00 00 00 00 00 00 00
+zSW0   ui32      4  00 00 00 00
+zSX0   hex_     13  00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ if [ ! -f ThermalForge.icns ]; then
 fi
 
 # Install CLI and daemon (handles stopping old daemon if present)
-sudo xattr -cr .build/release/thermalforge
+sudo xattr -c .build/release/thermalforge
 sudo .build/release/thermalforge install
 
 # Create .app bundle in /Applications so it shows in Spotlight/Finder
@@ -34,7 +34,7 @@ APP_DIR="/Applications/ThermalForge.app/Contents"
 sudo mkdir -p "$APP_DIR/MacOS" "$APP_DIR/Resources"
 sudo cp .build/release/ThermalForgeApp "$APP_DIR/MacOS/ThermalForgeApp"
 sudo cp ThermalForge.icns "$APP_DIR/Resources/AppIcon.icns"
-sudo xattr -cr /Applications/ThermalForge.app
+sudo find /Applications/ThermalForge.app -exec xattr -c {} + 2>/dev/null || true
 
 sudo tee "$APP_DIR/Info.plist" > /dev/null << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
**Fix macOS setup script xattr usage**

setup.sh was using `xattr -cr`, which fails on macOS because `xattr` does not support `-r`.

This change:
- uses `sudo xattr -c .build/release/thermalforge`
- clears xattrs recursively on ThermalForge.app with `find ... -exec xattr -c {} +`

That keeps the install flow working on macOS without the invalid `xattr` flag.

At least that is the case for my mac m1 pro on macos golden gate beta 2