### PR TITLE
cli: make `auto` a pure fan reset; quitting the menu bar app is opt-in via --stop-app

### DIFF
--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -58,14 +58,27 @@ struct Auto: ParsableCommand {
         abstract: "Reset fans to Apple defaults"
     )
 
+    @Flag(
+        name: .long,
+        help: """
+            Also quit the ThermalForge menu bar app after the reset so a running \
+            profile can't re-apply and undo it. Off by default; `auto` only \
+            touches the fans.
+            """
+    )
+    var stopApp: Bool = false
+
     func run() throws {
-        // Kill the menu bar app first — if it's running with a profile active,
-        // it will override the fan reset within seconds
-        let kill = Process()
-        kill.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-        kill.arguments = ["ThermalForgeApp"]
-        try? kill.run()
-        kill.waitUntilExit()
+        // A running app re-applies its profile after a reset, so making the
+        // reset "stick" requires quitting it. That is a heavy side effect,
+        // kept opt-in so `auto` stays a pure fan reset for any caller.
+        if stopApp {
+            let kill = Process()
+            kill.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+            kill.arguments = ["ThermalForgeApp"]
+            try? kill.run()
+            kill.waitUntilExit()
+        }
 
         let fc = try FanControl()
         try fc.resetAuto()


### PR DESCRIPTION
## Problem

`thermalforge auto` unconditionally runs `killall ThermalForgeApp` before resetting fans. Any program that shells out to the CLI to restore fans — scripts, benchmark harnesses, inference runtimes that pin fans during a run and restore them afterward — silently quits the user's menu bar app as a side effect. The caller asked for a fan reset and got their app closed.

## Change

The kill is now behind an explicit `--stop-app` flag; default `auto` touches only the fans.

The original rationale for the kill is real and preserved in the flag's help text: a running app with an active profile re-applies its curve within seconds, so a reset that must *stick* still wants `--stop-app`. But that is a policy decision for the caller, not something a fan reset should assume — and for callers coordinating with the daemon/app (rather than fighting it), the unconditional kill was purely destructive.

## Compatibility

Anyone depending on the old implicit behavior gets it back with `thermalforge auto --stop-app`. No other commands touched.

Build-verified with `swift build -c release`. Diff is confined to the `Auto` subcommand (+20/−7).