### PR TITLE
core: resetAuto no longer reports success when its SMC writes were rejected

### DIFF
--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -275,21 +275,37 @@ public final class FanControl {
 
     // MARK: - Reset
 
-    /// Reset all fans to Apple defaults (auto mode, thermalmonitord resumes)
+    /// Reset all fans to Apple defaults (auto mode, thermalmonitord resumes).
+    ///
+    /// Throws `writeFailed` if a mode or Ftst write is rejected (e.g. when run
+    /// without root). Those writes are what hand control back to macOS; a
+    /// rejected one leaves a fan latched in manual with the auto curve
+    /// suppressed, so it must never be reported as success. Every fan is
+    /// attempted before throwing, so a partial reset still resets what it can.
     public func resetAuto() throws {
         let count = try fanCount()
+        var failedKey: String?
 
         for i in 0..<count {
+            // The mode write returns the fan to macOS auto; a rejected one
+            // leaves it stuck in manual, so record it as a failure.
             let modeKey = SMCFanKey.key(modeKeyTemplate, fan: i)
-            _ = smc.writeKey(modeKey, bytes: [0])
+            if !smc.writeKey(modeKey, bytes: [0]) {
+                failedKey = failedKey ?? modeKey
+            }
 
+            // Target is advisory once mode is auto; clear it best-effort.
             let targetKey = SMCFanKey.key(SMCFanKey.target, fan: i)
             _ = smc.writeKey(targetKey, bytes: floatToSMCBytes(0))
         }
 
-        // Reset Ftst if it exists — thermalmonitord reclaims control
-        if hasFtst {
-            _ = smc.writeKey(SMCFanKey.forceTest, bytes: [0])
+        // Reset Ftst if it exists — thermalmonitord reclaims control (M1-M4).
+        if hasFtst, !smc.writeKey(SMCFanKey.forceTest, bytes: [0]) {
+            failedKey = failedKey ?? SMCFanKey.forceTest
+        }
+
+        if let key = failedKey {
+            throw ThermalForgeError.writeFailed(key)
         }
         log("Reset to Apple defaults")
     }


### PR DESCRIPTION
## Problem

`FanControl.resetAuto()` discarded the return value of every SMC write (`_ = smc.writeKey(...)`) and unconditionally logged "Reset to Apple defaults". When a write is rejected — the common case being a non-root caller, where AppleSMC allows reads but the firmware rejects fan-mode writes — the function reported success while the fans stayed latched in manual mode with the Apple auto curve suppressed. Every downstream surface then lied in turn: the CLI exited 0, and the daemon's `auto` verb replied `ok`.

This matters most for the mode and `Ftst` writes: they are precisely what hands control back to thermalmonitord. A rejected one is not a degraded reset, it is no reset.

## Change

- The per-fan mode write and the `Ftst` reset record the first rejected key; after **attempting every fan** (a partial reset still resets what it can), `resetAuto` throws `writeFailed(key)`.
- The target-RPM write remains best-effort: once mode is auto it is advisory, so its failure doesn't invalidate the reset.
- The success log is only reached on an actual success.

## Impact

Callers that run as root (the daemon, `sudo` CLI use) see no behavior change. Non-root callers now get an honest error instead of a silent no-op — which is what makes failures like "fans stuck at max after the app quit" diagnosable instead of invisible.

`resetAuto` was already `throws`; no signature change. Build-verified with `swift build -c release`. Diff: +21/−5 in `FanControl.swift`.