### PR TITLE
install: reinstalling from the installed binary deletes itself and orphans the root daemon

### DIFF
--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -487,14 +487,41 @@ struct Install: ParsableCommand {
         let binaryPath = ProcessInfo.processInfo.arguments[0]
         let installPath = ThermalForgeDaemon.installPath
 
-        // Copy binary to /usr/local/bin
         let fm = FileManager.default
         try? fm.createDirectory(
             atPath: "/usr/local/bin",
             withIntermediateDirectories: true
         )
-        try? fm.removeItem(atPath: installPath)
-        try fm.copyItem(atPath: binaryPath, toPath: installPath)
+
+        // argv[0] may itself be the installed binary, so source and target
+        // can be the same file: only copy when they differ, and never remove
+        // the target until a complete replacement sits next to it — the
+        // existing install must survive any failure in this sequence.
+        let sourceFile = URL(fileURLWithPath: binaryPath).resolvingSymlinksInPath().path
+        let targetFile = URL(fileURLWithPath: installPath).resolvingSymlinksInPath().path
+        var stagedPath: String?
+        if sourceFile != targetFile {
+            let staging = installPath + ".new"
+            try? fm.removeItem(atPath: staging)
+            try fm.copyItem(atPath: binaryPath, toPath: staging)
+            stagedPath = staging
+        }
+
+        // Stop the old daemon before the binary is swapped, so a daemon never
+        // keeps running from a deleted inode after a partial install.
+        if ThermalForgeDaemon.isRunning {
+            let unload = Process()
+            unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
+            try unload.run()
+            unload.waitUntilExit()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        if let staging = stagedPath {
+            try? fm.removeItem(atPath: installPath)
+            try fm.moveItem(atPath: staging, toPath: installPath)
+        }
 
         // Write launchd plist
         let plist = """
@@ -521,15 +548,6 @@ struct Install: ParsableCommand {
             toFile: ThermalForgeDaemon.plistPath,
             atomically: true, encoding: .utf8
         )
-        // Stop old daemon if one is running
-        if ThermalForgeDaemon.isRunning {
-            let unload = Process()
-            unload.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            unload.arguments = ["bootout", "system/\(ThermalForgeDaemon.label)"]
-            try unload.run()
-            unload.waitUntilExit()
-            Thread.sleep(forTimeInterval: 0.5)
-        }
 
         // Start new daemon
         let load = Process()


### PR DESCRIPTION
## Problem

`Install.run()` does remove-then-copy with `argv[0]` as the copy source:

```swift
try? fm.removeItem(atPath: installPath)
try fm.copyItem(atPath: binaryPath, toPath: installPath)
```

When a user reinstalls with `sudo thermalforge install` using the binary already on PATH — the natural invocation once installed — `argv[0]` *is* `/usr/local/bin/thermalforge`. The remove deletes the copy's own source (silently, it's `try?`), the copy then throws, and `run()` aborts mid-sequence. Observed result on a real machine:

- **no `thermalforge` binary anywhere on PATH** — both `thermalforge` and `sudo thermalforge` report "command not found" immediately after running the installer;
- the **old root daemon keeps running from the deleted inode**, invisible to any fix except a manual `launchctl bootout`;
- launchd keeps a `KeepAlive` plist pointing at a nonexistent file, so after the next reboot there is no daemon at all.

A secondary ordering flaw compounds it: the old daemon was booted out *after* the binary replacement, so even a successful reinstall briefly ran the old daemon on a deleted inode.

## Change

1. **Same-file guard**: resolve symlinks on both `argv[0]` and the install path; when they are the same file, skip the copy entirely (the binary is already in place — reinstall then just refreshes the plist and daemon).
2. **Staged copy**: when they differ, copy to `<installPath>.new` first and swap only after the copy succeeded — a failed copy can no longer destroy an existing install.
3. **Bootout before swap**: the old daemon is stopped before the binary is replaced, so no daemon ever survives on a deleted inode.

The install sequence is otherwise unchanged (plist write, `bootstrap`, verify).

Build-verified with `swift build -c release`. Diff: +31/−12, confined to `Install.run()`.