### PR TITLE
cli: route fan commands through the privileged daemon (stacked on #29)

### DIFF
--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -99,15 +99,44 @@ public final class DaemonClient {
         return response
     }
 
-    /// Send a FanCommand to the daemon
-    public func execute(_ command: FanCommand) throws {
+    /// Send a FanCommand to the daemon.
+    ///
+    /// `supervised` controls the daemon's heartbeat watchdog:
+    /// - `true` (default): the daemon arms the watchdog, so the caller must
+    ///   keep sending `heartbeat` (the menu bar app does). If it dies, fans
+    ///   revert to auto after ~15s. Use for long-lived owners.
+    /// - `false`: an unsupervised, fire-and-forget hold that persists after the
+    ///   caller exits. Use for one-shot CLI commands (`thermalforge max`/`set`).
+    ///
+    /// `resetAuto` is never watchdog-supervised, so `supervised` is ignored for it.
+    public func execute(_ command: FanCommand, supervised: Bool = true) throws {
+        let suffix = supervised ? "" : " nohb"
         let cmdString: String
         switch command {
-        case .setMax: cmdString = "max"
-        case .setRPM(let rpm): cmdString = "set \(Int(rpm))"
+        case .setMax: cmdString = "max" + suffix
+        case .setRPM(let rpm): cmdString = "set \(Int(rpm))" + suffix
         case .resetAuto: cmdString = "auto"
         }
         _ = try send(cmdString)
+    }
+}
+
+// MARK: - Command Router
+
+/// Applies a `FanCommand` through the best available transport: the privileged
+/// daemon when it's running (no sudo needed, coordinates with the menu bar app),
+/// or a direct SMC write otherwise (requires root). This is what lets the CLI
+/// work both with and without an installed daemon.
+public enum FanCommandRouter {
+    /// - Parameter supervised: forwarded to `DaemonClient.execute` when the
+    ///   daemon path is taken; ignored for the direct-SMC fallback. Defaults to
+    ///   `false` because the callers are one-shot commands that set fans and exit.
+    public static func apply(_ command: FanCommand, supervised: Bool = false) throws {
+        if ThermalForgeDaemon.isRunning {
+            try DaemonClient().execute(command, supervised: supervised)
+        } else {
+            try FanControl().apply(command)
+        }
     }
 }
 
@@ -311,13 +340,20 @@ public final class DaemonServer {
         smcLock.lock()
         defer { smcLock.unlock() }
         do {
-            let parts = command.split(separator: " ")
-            switch parts.first.map(String.init) {
+            // A trailing "nohb" token marks an unsupervised hold: set fans but
+            // leave the watchdog disarmed (lastHeartbeat = nil, not stale), so a
+            // fire-and-forget CLI command isn't reverted to auto 15s later. The
+            // menu bar app omits "nohb" and stays supervised / crash-protected.
+            var parts = command.split(separator: " ").map(String.init)
+            let unsupervised = parts.last == "nohb"
+            if unsupervised { parts.removeLast() }
+
+            switch parts.first {
             case "max":
                 try fanControl.setMax()
                 heartbeatLock.lock()
                 lastCommand = "max"
-                lastHeartbeat = Date()
+                lastHeartbeat = unsupervised ? nil : Date()
                 heartbeatLock.unlock()
                 response = "ok"
             case "auto":
@@ -334,8 +370,8 @@ public final class DaemonServer {
                 }
                 try fanControl.setAllFans(rpm: rpm)
                 heartbeatLock.lock()
-                lastCommand = command
-                lastHeartbeat = Date()
+                lastCommand = "set \(parts[1])"
+                lastHeartbeat = unsupervised ? nil : Date()
                 heartbeatLock.unlock()
                 response = "ok"
             case "status":

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -294,6 +294,18 @@ public final class FanControl {
         log("Reset to Apple defaults")
     }
 
+    // MARK: - Command Dispatch
+
+    /// Apply a high-level `FanCommand` with direct SMC writes (requires root).
+    /// The daemon-aware equivalent is `FanCommandRouter.apply(_:supervised:)`.
+    public func apply(_ command: FanCommand) throws {
+        switch command {
+        case .setMax: try setMax()
+        case .setRPM(let rpm): try setAllFans(rpm: rpm)
+        case .resetAuto: try resetAuto()
+        }
+    }
+
     // MARK: - Status
 
     /// Read current fan speeds and temperatures

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -40,10 +40,10 @@ struct Max: ParsableCommand {
     )
 
     func run() throws {
-        let fc = try FanControl()
-        try fc.setMax()
+        try FanCommandRouter.apply(.setMax)
 
-        let status = try fc.status()
+        // Reading status needs no privilege, so report it regardless of path.
+        let status = try FanControl().status()
         for fan in status.fans {
             print("Fan \(fan.index): \(fan.actualRPM) RPM → max (\(fan.maxRPM) RPM)")
         }
@@ -80,8 +80,7 @@ struct Auto: ParsableCommand {
             kill.waitUntilExit()
         }
 
-        let fc = try FanControl()
-        try fc.resetAuto()
+        try FanCommandRouter.apply(.resetAuto)
         print("Fans reset to Apple defaults")
     }
 }
@@ -101,15 +100,16 @@ struct SetSpeed: ParsableCommand {
     var fan: Int?
 
     func run() throws {
-        let fc = try FanControl()
         let target = Float(rpm)
 
+        // Per-fan control isn't exposed over the daemon socket (it only sets
+        // all fans), so a single-fan request still needs direct SMC access.
         if let index = fan {
-            try fc.setSpeed(fan: index, rpm: target)
+            try FanControl().setSpeed(fan: index, rpm: target)
             print("Fan \(index) → \(rpm) RPM")
         } else {
-            try fc.setAllFans(rpm: target)
-            let count = try fc.fanCount()
+            try FanCommandRouter.apply(.setRPM(target))
+            let count = try FanControl().fanCount()
             for i in 0..<count {
                 print("Fan \(i) → \(rpm) RPM")
             }
@@ -242,14 +242,8 @@ struct Watch: ParsableCommand {
         print("Hardware: \(fc.hardwareInfo)")
         print("Polling every \(interval)s. Ctrl-C to stop.\n")
 
-        // CLI runs as root, so fan commands go directly through FanControl
-        monitor.onFanCommand = { command in
-            switch command {
-            case .setMax: try fc.setMax()
-            case .setRPM(let rpm): try fc.setAllFans(rpm: rpm)
-            case .resetAuto: try fc.resetAuto()
-            }
-        }
+        // CLI runs as root, so fan commands go directly through FanControl.
+        monitor.onFanCommand = { command in try fc.apply(command) }
 
         monitor.onUpdate = { [json] status, activeProfile, state in
             if json {

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -58,14 +58,27 @@ struct Auto: ParsableCommand {
         abstract: "Reset fans to Apple defaults"
     )
 
+    @Flag(
+        name: .long,
+        help: """
+            Also quit the ThermalForge menu bar app after the reset so a running \
+            profile can't re-apply and undo it. Off by default; `auto` only \
+            touches the fans.
+            """
+    )
+    var stopApp: Bool = false
+
     func run() throws {
-        // Kill the menu bar app first — if it's running with a profile active,
-        // it will override the fan reset within seconds
-        let kill = Process()
-        kill.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-        kill.arguments = ["ThermalForgeApp"]
-        try? kill.run()
-        kill.waitUntilExit()
+        // A running app re-applies its profile after a reset, so making the
+        // reset "stick" requires quitting it. That is a heavy side effect,
+        // kept opt-in so `auto` stays a pure fan reset for any caller.
+        if stopApp {
+            let kill = Process()
+            kill.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+            kill.arguments = ["ThermalForgeApp"]
+            try? kill.run()
+            kill.waitUntilExit()
+        }
 
         let fc = try FanControl()
         try fc.resetAuto()


### PR DESCRIPTION
> **Depends on #29.** This branch is stacked on `fix/auto-app-kill-optin`; the first commit here *is* #29. Until #29 merges, please review only the top commit (`feat(cli): route fan commands through the privileged daemon`). Once #29 lands, this rebases to a single commit and the diff collapses to the routing change alone.

## Problem

The CLI's `max`, `set`, and `auto` always write to the SMC directly, which requires root. On a machine where the ThermalForge daemon is already running as root — the normal installed state — an unprivileged `thermalforge max` fails with "Fan unlock failed: Timed out setting fan 0 to manual mode. Run with sudo," because AppleSMC accepts reads but the firmware rejects every fan-mode write, and the unlock loop times out. Callers are forced into sudo (or fail) while a privileged path that already speaks `max`/`set`/`auto` sits idle on `/tmp/thermalforge.sock`. Direct writes also race the app→daemon control loop instead of coordinating with it.

## Change

- **`FanCommandRouter.apply`**: one entry point that uses the daemon when it's running (no sudo, coordinates with the app) and falls back to direct SMC writes otherwise (daemon-less installs behave exactly as before, including the sudo requirement).
- **CLI rewiring**: `max`, `set` (all fans), and `auto` go through the router. Single-fan `set --fan N` intentionally stays direct-to-SMC — per-fan control is not part of the socket protocol — and still needs sudo.
- **`nohb` (unsupervised hold)**: one-shot CLI commands append a `nohb` token so the daemon leaves its heartbeat watchdog disarmed; without it, the 15s watchdog silently reverts a fire-and-forget `thermalforge max` to auto. The menu bar app omits the token and stays supervised/crash-protected exactly as today.

## Compatibility

Older daemons tokenize on whitespace and ignore the trailing `nohb` for `max`/`set`, so a new CLI against an old daemon degrades to today's behavior (hold reverts after the watchdog window) rather than erroring. There is no CLI↔daemon version handshake in the protocol — that's noted here as future work rather than smuggled into this PR.

Build-verified with `swift build -c release`; the daemon-routed `max`/`status`/`auto` sequence was exercised end-to-end against a live root daemon on an M5 Max (fans commanded to 5349/5777 RPM without sudo, then restored).