### PR TITLE
fix: keep Smart mode responsive on newer Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Apple doesn't do this because silence sells in store demos and most users never 
 
 **0 to minimum RPM is binary:** Apple Silicon MacBook fans cannot spin below their minimum RPM (2317 on M5 Max, 1200 on M1 Max). When Smart decides fans should run, they jump directly to minimum — this is a hardware limitation of brushless DC motors that require a startup burst to overcome static friction. Above minimum, all speed changes are smooth and governed.
 
+### M4/M5 sensor and responsiveness safeguards
+
+On newer Apple Silicon machines, some legacy `Tp0*` keys may exist but return
+placeholder values. ThermalForge prefers the machine's aggregate `TC*` CPU
+sensors when they are available, and falls back to the legacy family only when
+they are not. Full telemetry is refreshed once per second while the 100ms fan
+ramp remains active; this keeps Smart responsive without repeatedly issuing a
+large burst of SMC reads. Daemon commands run off the menu-bar actor as well, so
+a slow privileged-daemon response cannot freeze the menu bar.
+
 ### FAQ
 
 **What if ThermalForge closes during normal use?**

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -12,6 +12,8 @@ import SwiftUI
 @MainActor
 final class AppState: ObservableObject {
     @Published var latestStatus: ThermalStatus?
+    // Keep Apple-default behavior on first launch. Smart remains selectable
+    // from the menu bar; the local diagnostic build used Smart explicitly.
     @Published var activeProfile: FanProfile = .silent
     @Published var monitorState: MonitorState = .idle
     @Published var maxTemp: Float?
@@ -35,6 +37,12 @@ final class AppState: ObservableObject {
     private var monitor: ThermalMonitor?
     private let executor = PrivilegedExecutor()
     private var heartbeatTimer: Timer?
+    private var heartbeatInFlight = false
+    /// Daemon commands are serialized and coalesced. A stalled daemon must not
+    /// create one detached task per 100ms ramp tick; only the newest pending
+    /// RPM target is useful once the socket becomes available again.
+    private var pendingFanCommand: FanCommand?
+    private var fanCommandInFlight = false
 
     init() {
         launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -92,8 +100,22 @@ final class AppState: ObservableObject {
     // MARK: - Heartbeat
 
     private func startHeartbeat() {
-        let client = DaemonClient()
         heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.startHeartbeatRequest()
+            }
+        }
+    }
+
+    @MainActor
+    private func startHeartbeatRequest() {
+        guard !heartbeatInFlight else { return }
+        heartbeatInFlight = true
+
+        // Every daemon request has bounded socket I/O, but keep the whole
+        // heartbeat off MainActor so a slow daemon can never pause SwiftUI.
+        Task.detached { [weak self] in
+            let client = DaemonClient()
             _ = try? client.send("heartbeat")
 
             // Piggyback a version check on the heartbeat. Detect the raw "error:"
@@ -111,11 +133,15 @@ final class AppState: ObservableObject {
             // menu bar and suspends our monitor (nil if unreadable — don't guess).
             let hold = try? client.readState()
 
-            Task { @MainActor [weak self] in
-                self?.daemonVersionMismatch = mismatch
-                self?.externalHold = (hold?.isCLIHold == true) ? hold : nil
-            }
+            await self?.completeHeartbeat(mismatch: mismatch, hold: hold)
         }
+    }
+
+    @MainActor
+    private func completeHeartbeat(mismatch: String?, hold: DaemonHoldState?) {
+        daemonVersionMismatch = mismatch
+        externalHold = (hold?.isCLIHold == true) ? hold : nil
+        heartbeatInFlight = false
     }
 
     // MARK: - Monitoring
@@ -129,9 +155,11 @@ final class AppState: ObservableObject {
                 self?.latestStatus = status
                 self?.activeProfile = profile
                 self?.monitorState = state
-                // Max of only the displayed sensors
-                // Peak across all CPU and GPU sensors for menu bar display
-                let displayPrefixes = ["TC", "Tp", "TG", "Tg"]
+                // Prefer aggregate TC* sensors when present. The Tp0* aliases
+                // on M4/M5 can be placeholder values and must not drive the UI
+                // temperature or Smart profile.
+                let hasAggregateCPU = status.temperatures.keys.contains { $0.hasPrefix("TC") }
+                let displayPrefixes = hasAggregateCPU ? ["TC", "TG", "Tg"] : ["Tp", "TG", "Tg"]
                 self?.maxTemp = status.temperatures
                     .filter { key, _ in displayPrefixes.contains(where: { key.hasPrefix($0) }) }
                     .values.max()
@@ -144,20 +172,56 @@ final class AppState: ObservableObject {
                 // monitor resumes control when they pick a profile or press
                 // Default (which clears externalHold).
                 guard self.externalHold == nil else { return }
-                do {
-                    try self.executor.execute(command)
-                } catch {
-                    // Daemon rejected us because a CLI hold owns the fans. Latch
-                    // it now (don't wait up to 5s for the poll) so the monitor
-                    // stops trying and the banner appears immediately.
-                    if let state = try? DaemonClient().readState(), state.isCLIHold {
-                        self.externalHold = state
-                    }
-                }
+
+                // DaemonClient.sendRaw performs a blocking Unix-socket read.
+                // Never run it on MainActor: a slow SMC transaction must not
+                // freeze the menu bar or make Bartender appear to intercept it.
+                self.enqueueFanCommand(command)
             }
         }
         monitor.start()
         self.monitor = monitor
+    }
+
+    @MainActor
+    private func latchExternalHold(_ state: DaemonHoldState) {
+        externalHold = state
+    }
+
+    @MainActor
+    private func enqueueFanCommand(_ command: FanCommand) {
+        pendingFanCommand = command
+        guard !fanCommandInFlight else { return }
+        fanCommandInFlight = true
+        drainFanCommandQueue()
+    }
+
+    @MainActor
+    private func drainFanCommandQueue() {
+        guard let command = pendingFanCommand else {
+            fanCommandInFlight = false
+            return
+        }
+        pendingFanCommand = nil
+        let executor = self.executor
+
+        Task.detached { [weak self, executor] in
+            do {
+                try executor.execute(command)
+            } catch {
+                // Daemon rejected us because a CLI hold owns the fans. Latch it
+                // immediately, but publish the state on MainActor.
+                if let state = try? DaemonClient().readState(), state.isCLIHold {
+                    await self?.latchExternalHold(state)
+                }
+            }
+            await self?.fanCommandFinished()
+        }
+    }
+
+    @MainActor
+    private func fanCommandFinished() {
+        drainFanCommandQueue()
     }
 
     // MARK: - Actions

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -209,11 +209,10 @@ final class AppState: ObservableObject {
             do {
                 try executor.execute(command)
             } catch {
-                // Daemon rejected us because a CLI hold owns the fans. Latch it
-                // immediately, but publish the state on MainActor.
-                if let state = try? DaemonClient().readState(), state.isCLIHold {
-                    await self?.latchExternalHold(state)
-                }
+                // Do not follow a timed-out command with another blocking
+                // state read. The non-overlapping heartbeat owns hold-state
+                // reconciliation and will publish a CLI hold on its next pass.
+                TFLogger.shared.error("Fan command failed: \(command) — \(error)")
             }
             await self?.fanCommandFinished()
         }

--- a/Sources/ThermalForgeApp/ThermalForgeApp.swift
+++ b/Sources/ThermalForgeApp/ThermalForgeApp.swift
@@ -46,10 +46,11 @@ struct ThermalForgeApp: App {
                 needsDaemonUpdate: appState.daemonVersionMismatch != nil
             )
         }
-        // The native menu style keeps the status item discoverable to
-        // macOS/Bartender on newer beta releases. The window style can leave
-        // an accessory app running with no clickable status item.
-        .menuBarExtraStyle(.menu)
+        // MenuBarView is a rich custom panel (live telemetry, inline profile
+        // picker, banners and bordered controls), so it must use window style.
+        // Native menu style can register the status item yet fail to present
+        // this view when clicked on newer macOS releases.
+        .menuBarExtraStyle(.window)
     }
 }
 

--- a/Sources/ThermalForgeApp/ThermalForgeApp.swift
+++ b/Sources/ThermalForgeApp/ThermalForgeApp.swift
@@ -46,7 +46,10 @@ struct ThermalForgeApp: App {
                 needsDaemonUpdate: appState.daemonVersionMismatch != nil
             )
         }
-        .menuBarExtraStyle(.window)
+        // The native menu style keeps the status item discoverable to
+        // macOS/Bartender on newer beta releases. The window style can leave
+        // an accessory app running with no clickable status item.
+        .menuBarExtraStyle(.menu)
     }
 }
 

--- a/Sources/ThermalForgeCore/Daemon.swift
+++ b/Sources/ThermalForgeCore/Daemon.swift
@@ -114,6 +114,11 @@ public struct DaemonHoldState: Codable, Equatable {
 }
 
 public final class DaemonClient {
+    /// A daemon-side SMC stall must not leave callers blocked forever. The app
+    /// treats a timeout like an unreachable daemon and lets the watchdog/reset
+    /// path recover on the next cycle.
+    private static let ioTimeoutSeconds: Int = 2
+
     public init() {}
 
     /// Read the daemon's current hold (what's set and who owns it) so the menu
@@ -149,6 +154,14 @@ public final class DaemonClient {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw DaemonError.connectionFailed }
         defer { close(fd) }
+
+        var timeout = timeval(tv_sec: Self.ioTimeoutSeconds, tv_usec: 0)
+        _ = withUnsafePointer(to: &timeout) {
+            setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, $0, socklen_t(MemoryLayout<timeval>.size))
+        }
+        _ = withUnsafePointer(to: &timeout) {
+            setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, $0, socklen_t(MemoryLayout<timeval>.size))
+        }
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)

--- a/Sources/ThermalForgeCore/FanControl.swift
+++ b/Sources/ThermalForgeCore/FanControl.swift
@@ -70,6 +70,10 @@ public final class FanControl {
     private let modeKeyTemplate: String
     /// Whether Ftst unlock is available (M1-M4) or not (M5+)
     private let hasFtst: Bool
+    /// Temperature keys to query for this machine. M4/M5 machines expose a
+    /// stable aggregate CPU temperature, while legacy Tp0* aliases can return
+    /// placeholder values on those machines.
+    private let fltTemperatureKeys: [String]
 
     public init() throws {
         guard let connection = SMCConnection() else {
@@ -92,6 +96,20 @@ public final class FanControl {
         } else {
             self.hasFtst = false
         }
+
+        let aggregateCPUKeys = ["TCDX", "TCHP", "TCMb"]
+        let legacyCPUKeys = [
+            "Tp01", "Tp02", "Tp03", "Tp04", "Tp05", "Tp06", "Tp07", "Tp08",
+            "Tp09", "Tp0A", "Tp0B", "Tp0C", "Tp0D", "Tp0F", "Tp0G", "Tp0H",
+            "Tp0J", "Tp0L", "Tp0P", "Tp0S", "Tp0T", "Tp0W", "Tp0X", "Tp0b",
+        ]
+        let hasAggregateCPU = aggregateCPUKeys.contains { connection.getKeyInfo($0)?.size == 4 }
+
+        self.fltTemperatureKeys = (hasAggregateCPU ? aggregateCPUKeys : legacyCPUKeys) + [
+            "Tg05", "Tg0D", "Tg0L", "Tg0T", "Tg0f", "Tg0j",
+            "Tm02", "Tm06", "Tm08", "Tm09", "TRDX", "TMVR",
+            "TPDX", "TH0x", "TH0A", "TH0B", "TAOL", "TA0P", "TS0P", "TB0T",
+        ]
     }
 
     // MARK: - Fan Count
@@ -313,38 +331,12 @@ public final class FanControl {
             ))
         }
 
-        // Probe temperature keys across all known Apple Silicon generations.
-        // Keys that don't exist on a given machine are skipped automatically.
-        // Labels use the raw SMC key name — no assumptions about what a key
-        // means on hardware we haven't verified.
+        // Probe only the temperature family appropriate for this machine.
+        // On M4/M5, Tp0* aliases are present but are not reliable thermal
+        // sensors; querying them also adds substantial SMC traffic.
         var temps: [String: Float] = [:]
 
-        // All known CPU/GPU/memory/misc thermal keys (flt type, 4 bytes)
-        let fltKeys: [String] = [
-            // CPU — aggregate (M5 Max verified)
-            "TCDX", "TCHP", "TCMb",
-            // CPU — per-core (Tp prefix, present across M1-M5 with varying mappings)
-            "Tp01", "Tp02", "Tp03", "Tp04", "Tp05", "Tp06", "Tp07", "Tp08",
-            "Tp09", "Tp0A", "Tp0B", "Tp0C", "Tp0D", "Tp0F", "Tp0G", "Tp0H",
-            "Tp0J", "Tp0L", "Tp0P", "Tp0S", "Tp0T", "Tp0W", "Tp0X", "Tp0b",
-            // GPU (flt type — M1 through M4)
-            "Tg05", "Tg0D", "Tg0L", "Tg0T", "Tg0f", "Tg0j",
-            // Memory
-            "Tm02", "Tm06", "Tm08", "Tm09",
-            "TRDX", "TMVR",
-            // Power delivery
-            "TPDX",
-            // SSD
-            "TH0x", "TH0A", "TH0B",
-            // Ambient
-            "TAOL", "TA0P",
-            // Proximity
-            "TS0P",
-            // Battery
-            "TB0T",
-        ]
-
-        for key in fltKeys {
+        for key in fltTemperatureKeys {
             let result = smc.readKey(key)
             if result.success && result.size == 4 {
                 let temp = smcBytesToFloat(result.bytes, size: result.size)

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -69,6 +69,11 @@ public final class ThermalMonitor {
     /// At 100ms thermal tick, 5 × 0.1s = 500ms — smooth UI without excessive redraws.
     private static let uiUpdateCadence = 5
 
+    /// Fan hardware does not benefit from ten tiny RPM writes per second. Keep
+    /// telemetry/UI responsive at 100ms while limiting Smart's daemon traffic
+    /// to two coalescible commands per second during a ramp.
+    private static let smartCommandCadence = 5
+
     private var tickCounter = 0
 
     /// A full status read performs many IOKit calls. Refreshing it at 100ms
@@ -403,12 +408,31 @@ public final class ThermalMonitor {
             targetPct = minPct
         }
 
-        // Ramp governors — per-profile rates, per-tick amounts
-        let rampUp = activeProfile.curve.rampUpPerSec * tickInterval
-        let rampDown = activeProfile.curve.rampDownPerSec * tickInterval
+        // Calculate continuously, but only write fan hardware at a useful
+        // cadence. This prevents the 100ms control loop from saturating the
+        // daemon with changes smaller than the fan can physically express.
+        guard tickCounter % Self.smartCommandCadence == 0 else {
+            if fansCurrentlyRunning {
+                state = .active(profileName: "Smart")
+            }
+            return
+        }
+
+        // Ramp governors — scaled to the command cadence so the configured
+        // percent-per-second behavior is unchanged.
+        let commandInterval = tickInterval * Float(Self.smartCommandCadence)
+        let rampUp = activeProfile.curve.rampUpPerSec * commandInterval
+        let rampDown = activeProfile.curve.rampDownPerSec * commandInterval
 
         if targetPct > lastAppliedRPMPercent {
-            targetPct = min(targetPct, lastAppliedRPMPercent + rampUp)
+            // A manual fan cannot run below its hardware minimum. Jump directly
+            // to that minimum on engagement instead of sending the same minimum
+            // RPM repeatedly while an imaginary sub-minimum percentage ramps.
+            if lastAppliedRPMPercent == 0 {
+                targetPct = minPct
+            } else {
+                targetPct = min(targetPct, lastAppliedRPMPercent + rampUp)
+            }
         } else if targetPct < lastAppliedRPMPercent {
             targetPct = max(targetPct, lastAppliedRPMPercent - rampDown)
         }

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -71,6 +71,13 @@ public final class ThermalMonitor {
 
     private var tickCounter = 0
 
+    /// A full status read performs many IOKit calls. Refreshing it at 100ms
+    /// can starve the privileged daemon and produce placeholder SMC values.
+    /// Keep the control loop at 100ms, but refresh telemetry once per second.
+    private let statusRefreshInterval: TimeInterval = 1.0
+    private var cachedStatus: ThermalStatus?
+    private var lastStatusRead: DispatchTime?
+
     // MARK: - Fan State
 
     private var lastAppliedRPMPercent: Float = 0
@@ -80,6 +87,9 @@ public final class ThermalMonitor {
     // MARK: - Smart Profile State
 
     private var tempHistory: [Float] = []
+    /// Low-pass filtered control temperature. This prevents a single stale or
+    /// malformed SMC sample from causing a full fan ramp or a false anomaly.
+    private var filteredControlTemp: Float?
 
     // MARK: - Anomaly Detection
 
@@ -149,6 +159,7 @@ public final class ThermalMonitor {
             if profile.id == "smart" {
                 // Reset Smart state and reload calibration data
                 tempHistory.removeAll()
+                filteredControlTemp = nil
                 let loaded = CalibrationData.load()
                 if let error = loaded?.validationError {
                     TFLogger.shared.error("Calibration data rejected on reload: \(error)")
@@ -165,15 +176,30 @@ public final class ThermalMonitor {
     // MARK: - Polling
 
     private func tick() {
-        guard let status = try? fanControl.status() else { return }
+        let now = DispatchTime.now()
+        let shouldRefresh: Bool
+        if let last = lastStatusRead {
+            let elapsed = Double(now.uptimeNanoseconds - last.uptimeNanoseconds) / 1_000_000_000
+            shouldRefresh = elapsed >= statusRefreshInterval
+        } else {
+            shouldRefresh = true
+        }
+        if shouldRefresh, let fresh = try? fanControl.status() {
+            cachedStatus = fresh
+            lastStatusRead = now
+        }
+        guard let status = cachedStatus else { return }
         latestStatus = status
 
         // Extract peak temperatures
-        // CPU: aggregate keys (M5) + per-core keys (M1-M4)
-        let cpuTemp = peakTemp(status, prefixes: ["TC", "Tp"])
+        // Prefer aggregate TC* sensors when present. On M4/M5 the legacy Tp0*
+        // aliases can be placeholder values and falsely report 70–80°C.
+        let aggregateCPU = peakTemp(status, prefixes: ["TC"])
+        let cpuTemp = aggregateCPU > 0 ? aggregateCPU : peakTemp(status, prefixes: ["Tp"])
         // GPU: ioft keys (M5) + flt keys (M1-M4)
         let gpuTemp = peakTemp(status, prefixes: ["TG", "Tg"])
-        let maxTemp = max(cpuTemp, gpuTemp)
+        let rawMaxTemp = max(cpuTemp, gpuTemp)
+        let maxTemp = stabilizedTemperature(rawMaxTemp, refresh: shouldRefresh)
 
         // Monitor cadence: process capture + anomaly detection (every 2 seconds)
         if tickCounter % Self.monitorCadence == 0 {
@@ -351,7 +377,8 @@ public final class ThermalMonitor {
             if rate > 0 {
                 // Rising: boost proportionally to rate and proximity to ceiling
                 let urgency = min(max((peakTemp - Self.smartFloor) / (Self.smartCeiling - Self.smartFloor), 0), 1)
-                targetPct = min(targetPct + rate * 0.15 * (1 + urgency), 1.0)
+                let lead = min(rate * 0.08 * (1 + urgency), 0.25)
+                targetPct = min(targetPct + lead, 1.0)
             }
         } else {
             // Uncalibrated: S-curve (matches profile curveShape)
@@ -360,7 +387,9 @@ public final class ThermalMonitor {
             targetPct = position * position * (3 - 2 * position)
 
             if rate > 0 {
-                targetPct = min(targetPct + rate * 0.2, 1.0)
+                // Rate-of-change is a modest lead term, not a second control
+                // loop. The ramp governor remains the primary limiter.
+                targetPct = min(targetPct + min(rate * 0.08, 0.25), 1.0)
             }
         }
 
@@ -409,7 +438,28 @@ public final class ThermalMonitor {
         let newest = tempHistory.last!
         // tempHistory sampled at monitor cadence (2s intervals)
         let seconds = Float(tempHistory.count - 1) * Float(Self.monitorCadence) * tickInterval
-        return (newest - oldest) / seconds
+        // Ignore impossible slopes from a single stale SMC sample. A real
+        // sustained thermal change still passes through this bound.
+        return min(max((newest - oldest) / seconds, -3.0), 3.0)
+    }
+
+    /// Smooth only when a fresh SMC snapshot arrives. The one-second refresh
+    /// cadence makes the step limit meaningful and leaves the 100ms fan ramp
+    /// loop responsive without hammering AppleSMC.
+    private func stabilizedTemperature(_ raw: Float, refresh: Bool) -> Float {
+        guard refresh else { return filteredControlTemp ?? raw }
+        guard raw.isFinite, raw > 0, raw < 150 else {
+            return filteredControlTemp ?? 0
+        }
+        guard let previous = filteredControlTemp else {
+            filteredControlTemp = raw
+            return raw
+        }
+
+        let bounded = min(max(raw, previous - 8.0), previous + 8.0)
+        let filtered = previous * 0.65 + bounded * 0.35
+        filteredControlTemp = filtered
+        return filtered
     }
 
     // MARK: - Curve-Based Profiles


### PR DESCRIPTION
## What this fixes

On newer Apple Silicon machines, legacy `Tp0*` temperature aliases can return placeholder values and the 100ms full-status poll can generate excessive SMC traffic. The app also performed blocking daemon socket reads on the menu-bar actor, which could make the UI appear frozen or make a menu-bar utility such as Bartender look like it intercepted the click.

This patch:

- prefers available aggregate `TC*` CPU sensors and falls back to the legacy family only when needed;
- refreshes full telemetry once per second while keeping the 100ms calculation loop;
- smooths and bounds Smart-mode control temperature/rate inputs;
- limits Smart fan writes to two coalescible commands per second while preserving the configured ramp rate;
- jumps directly to the fan's hardware minimum on engagement instead of repeatedly sending an unachievable sub-minimum ramp;
- adds a two-second receive/send timeout to daemon Unix-socket I/O;
- moves heartbeat/version/hold polling off MainActor;
- serializes and coalesces fan commands so a stalled daemon cannot accumulate one task per calculation tick;
- avoids following a timed-out fan command with a second blocking state read;
- retains `.window` presentation for the rich menu-bar panel;
- keeps Apple-default behavior on first launch; Smart remains user-selectable;
- documents the safeguards.

## Verification

- `swift build -c release --product ThermalForgeApp` passes on the affected M4 Pro host (only CommandLineTools search-path linker warnings remain).
- `git diff --check` passes.
- Credential-shaped scan is clean.
- Live M4 Pro verification: Smart engaged at approximately 1,350 RPM; repeated `sample` captures showed the main thread in AppKit event handling rather than `DaemonClient.sendRaw`/`read`.
- The installed menu-bar app opens and its rich panel responds after consolidating two locally installed bundles with the same identifier; that local cleanup is not part of this source PR.
- `swift test` builds the test bundle but cannot execute in the local CommandLineTools-only environment because `Testing.framework` is absent. Full Xcode/CI is still required for the Swift Testing suite.

This is intentionally a source-level fix; no daemon install or system-wide replacement is included in the PR.
