### PR TITLE
fix: don't drop fan control when the profile menu re-renders

### DIFF
--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -404,6 +404,10 @@ final class AppState: ObservableObject {
     }
 
     func selectProfile(_ profile: FanProfile) {
+        // switchProfile zeroes the ramp governor and a handsOff profile also hands
+        // fans back to Apple auto, so re-selecting what is already active must not
+        // reach either. An external hold is the one reason to run it again.
+        guard profile.id != activeProfile.id || externalHold != nil else { return }
         let took = seizeControl()
         activeProfile = profile
         monitor?.switchProfile(profile)

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -92,11 +92,13 @@ struct MenuBarView: View {
             // Profile picker
             SectionHeader(title: "PROFILE")
             // Buttons, not a Picker: an inline Picker's binding is written by
-            // SwiftUI on re-render, not only on a click. After a wake the panel
-            // re-rendered and wrote the first row (Silent) before re-asserting the
-            // real profile. Silent is handsOff, so that echo reset fans to Apple
-            // auto and zeroed the ramp governor mid-heat-up. A Button action can
-            // only come from a gesture.
+            // SwiftUI on re-render, not only on a click. Every re-render writes the
+            // first row (Silent) before re-asserting the real profile, logged as a
+            // same-second "Selected: Silent" / "Selected: Performance" pair. One such
+            // pair fired at 01:21:27 with no user present -- pmset puts that inside
+            // DarkWake (01:21:03), six seconds before DarkWake to FullWake (01:21:33).
+            // Silent is handsOff, so the echo hands fans back to Apple auto and zeroes
+            // the ramp governor. A Button action can only come from a gesture.
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(FanProfile.builtIn) { profile in
                     Button(action: { appState.selectProfile(profile) }) {

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -91,43 +91,47 @@ struct MenuBarView: View {
 
             // Profile picker
             SectionHeader(title: "PROFILE")
-            Picker("Profile", selection: Binding(
-                get: { appState.activeProfile.id },
-                set: { id in
-                    if let profile = FanProfile.builtIn.first(where: { $0.id == id }) {
-                        appState.selectProfile(profile)
-                    }
-                }
-            )) {
+            // Buttons, not a Picker: an inline Picker's binding is written by
+            // SwiftUI on re-render, not only on a click. After a wake the panel
+            // re-rendered and wrote the first row (Silent) before re-asserting the
+            // real profile. Silent is handsOff, so that echo reset fans to Apple
+            // auto and zeroed the ramp governor mid-heat-up. A Button action can
+            // only come from a gesture.
+            VStack(alignment: .leading, spacing: 0) {
                 ForEach(FanProfile.builtIn) { profile in
-                    HStack {
-                        Text(profile.name)
-                        Spacer()
-                        if !profile.curve.handsOff {
-                            let unit = appState.useFahrenheit ? "F" : "C"
-                            if profile.curve.instantEngage {
-                                // Max: show instant trigger temp
-                                let startC = profile.curve.startTemp
-                                let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
-                                Text("\(Int(startDisp))°\(unit) instant")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            } else {
-                                let startC = profile.curve.startTemp
-                                let ceilC = profile.curve.ceilingTemp
-                                let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
-                                let ceilDisp = appState.useFahrenheit ? ceilC * 9 / 5 + 32 : ceilC
-                                Text("\(Int(startDisp))→\(Int(ceilDisp))°\(unit)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                    Button(action: { appState.selectProfile(profile) }) {
+                        HStack {
+                            Image(systemName: "checkmark")
+                                .font(.caption)
+                                .opacity(appState.activeProfile.id == profile.id ? 1 : 0)
+                            Text(profile.name)
+                            Spacer()
+                            if !profile.curve.handsOff {
+                                let unit = appState.useFahrenheit ? "F" : "C"
+                                if profile.curve.instantEngage {
+                                    // Max: show instant trigger temp
+                                    let startC = profile.curve.startTemp
+                                    let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
+                                    Text("\(Int(startDisp))°\(unit) instant")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    let startC = profile.curve.startTemp
+                                    let ceilC = profile.curve.ceilingTemp
+                                    let startDisp = appState.useFahrenheit ? startC * 9 / 5 + 32 : startC
+                                    let ceilDisp = appState.useFahrenheit ? ceilC * 9 / 5 + 32 : ceilC
+                                    Text("\(Int(startDisp))→\(Int(ceilDisp))°\(unit)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
                         }
+                        .contentShape(Rectangle())
                     }
-                    .tag(profile.id)
+                    .buttonStyle(.plain)
+                    .padding(.vertical, 3)
                 }
             }
-            .pickerStyle(.inline)
-            .labelsHidden()
             .padding(.horizontal, 12)
 
             Divider().padding(.vertical, 4)

--- a/Sources/ThermalForgeCore/Profile.swift
+++ b/Sources/ThermalForgeCore/Profile.swift
@@ -272,4 +272,7 @@ extension FanProfile {
     public static let safetyTempThreshold: Float = 95.0
     /// Hysteresis deadband to prevent oscillation
     public static let hysteresisDegrees: Float = 5.0
+    /// Above this, profiles drop their sustained trigger and ramp-up governor.
+    /// Both are acoustic comfort; neither is worth reaching safetyTempThreshold for.
+    public static let dangerZoneTemp: Float = 85.0
 }

--- a/Sources/ThermalForgeCore/ThermalMonitor.swift
+++ b/Sources/ThermalForgeCore/ThermalMonitor.swift
@@ -299,6 +299,9 @@ public final class ThermalMonitor {
     private static let smartStopTemp: Float = 50.0
 
     private func tickSmart(status: ThermalStatus, peakTemp: Float) {
+        // Same race as tickCurve — see the comment there.
+        let inDangerZone = peakTemp >= FanProfile.dangerZoneTemp
+
         // Sample temperature history at monitor cadence (2s) for stable rate-of-change
         if tickCounter % Self.monitorCadence == 0 {
             tempHistory.append(peakTemp)
@@ -331,7 +334,7 @@ public final class ThermalMonitor {
 
         // Sustained trigger: per-profile duration
         let sustainedTicksNeeded = Int(activeProfile.curve.sustainedTriggerSec / tickInterval)
-        if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded {
+        if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded && !inDangerZone {
             if sustainedAboveCount == 1 {
                 TFLogger.shared.fan("Sustained trigger: \(String(format: "%.1f", peakTemp))°C — waiting (\(sustainedAboveCount)/\(sustainedTicksNeeded)) [Smart]")
             }
@@ -375,7 +378,7 @@ public final class ThermalMonitor {
         let rampUp = activeProfile.curve.rampUpPerSec * tickInterval
         let rampDown = activeProfile.curve.rampDownPerSec * tickInterval
 
-        if targetPct > lastAppliedRPMPercent {
+        if targetPct > lastAppliedRPMPercent && !inDangerZone {
             targetPct = min(targetPct, lastAppliedRPMPercent + rampUp)
         } else if targetPct < lastAppliedRPMPercent {
             targetPct = max(targetPct, lastAppliedRPMPercent - rampDown)
@@ -416,6 +419,12 @@ public final class ThermalMonitor {
         let maxRPM = status.fans.first.map { Float($0.maxRPM) } ?? 7826
         let minRPM = status.fans.first.map { Float($0.minRPM) } ?? 2317
 
+        // Newer Apple Silicon covers startTemp -> safetyTempThreshold in under ten
+        // seconds, less than the sustained trigger plus the governed ramp takes to
+        // reach the curve's target. Waiting means the 95C override is what spins
+        // the fans, in one step from a standstill. Past dangerZoneTemp, drop both.
+        let inDangerZone = peakTemp >= FanProfile.dangerZoneTemp
+
         // Hands-off profiles (Silent): don't control fans, just monitor
         if curve.handsOff {
             if fansCurrentlyRunning {
@@ -443,7 +452,7 @@ public final class ThermalMonitor {
         // Sustained trigger: per-profile duration.
         // Converted to tick count at runtime based on tick interval.
         let sustainedTicksNeeded = Int(curve.sustainedTriggerSec / tickInterval)
-        if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded {
+        if !fansCurrentlyRunning && sustainedAboveCount < sustainedTicksNeeded && !inDangerZone {
             if sustainedAboveCount == 1 {
                 TFLogger.shared.fan("Sustained trigger: \(String(format: "%.1f", peakTemp))°C — waiting (\(sustainedAboveCount)/\(sustainedTicksNeeded)) [\(activeProfile.name)]")
             }
@@ -461,11 +470,11 @@ public final class ThermalMonitor {
         let rampDown = curve.rampDownPerSec * tickInterval
 
         if targetPct > lastAppliedRPMPercent {
-            if !curve.instantEngage {
+            if !curve.instantEngage && !inDangerZone {
                 // Governed ramp-up
                 targetPct = min(targetPct, lastAppliedRPMPercent + rampUp)
             }
-            // instantEngage: skip governor, jump directly to target
+            // instantEngage / danger zone: skip governor, jump directly to target
         } else if targetPct < lastAppliedRPMPercent {
             // Ramp-down governor always applies (even for instantEngage profiles)
             targetPct = max(targetPct, lastAppliedRPMPercent - rampDown)


### PR DESCRIPTION
> **Correction (2026-08-26).** This PR was originally filed as the fix for "fans slam to 100% after wake". **That attribution was wrong** and the body below has been rewritten. The 100% events on my machine came from a *second* SMC writer — Stats.app's root helper — not from ThermalForge. Details in the comment below.
>
> The defect this PR actually fixes is real and independently evidenced, so the code stands: the profile picker silently hands fan control back to Apple on every panel re-render. I have kept the PR open on those merits alone.

## What this fixes

`MenuBarView` drove the profile list through a `Picker` with a custom `Binding`. SwiftUI writes a `Picker`'s binding on re-render, not only on a click. Every re-render writes the first row (`silent`) through `set`, then re-asserts the real profile, producing this pair in the log:

```
[2026-08-25T23:21:27Z] [PROFILE] Selected: Silent (Apple Default)
[2026-08-25T23:21:27Z] [PROFILE] Selected: Performance
```

`silent` is `handsOff`, so `selectProfile` submits `.resetAuto` (fans back to Apple auto) and `ThermalMonitor.switchProfile` zeroes `lastAppliedRPMPercent`, `fansCurrentlyRunning` and `sustainedAboveCount`. Eight seconds later the log confirms the state: `Fan0: 0 RPM (auto) | Profile: Performance`. The user's chosen profile is showing in the menu while the machine is on Apple's curve.

This is not a user clicking twice. `selectProfile` has exactly one call site, the Picker binding, and at least one of these pairs fired with nobody at the machine — `pmset -g log` puts 01:21:27 local inside `DarkWake` (entered 01:21:03), six seconds before `DarkWake to FullWake` (01:21:33), display off.

Observed on an M5 Pro (Mac17,8), macOS 26.6.2, ThermalForge 0.2.2.

## Changes

- **`MenuBarView`**: `Button` rows instead of a `Picker` binding. `.tag(profile.id)` was already present, so tag inference was not the problem — the issue is that a binding's `set` is not a gesture. A `Button` action can only originate from one. Same layout, checkmark on the active row (also what #27 asks for on Smart).
- **`AppState.selectProfile`**: re-selecting the already-active profile is a no-op, so it cannot reach `switchProfile` or the `handsOff` reset. An active external hold is the one reason to still run it.
- **`ThermalMonitor` / `FanProfile`**: new `FanProfile.dangerZoneTemp` (85°C). Above it, `tickCurve` and `tickSmart` drop the sustained trigger and the ramp-up governor. Both are acoustic comfort and neither is worth reaching `safetyTempThreshold` for. The ramp-**down** governor is untouched, so this cannot cause fan hunting.

The danger-zone change stands on its own log evidence, independent of the correction above:

```
21:46:03Z  [FAN]     Fans on: 1350 RPM at 76.0°C [Performance]
21:46:07Z  [SAFETY]  Override triggered: 95.2°C — fans maxed
```

Four seconds from first engagement to the 95°C override. The governed ramp from 1350 RPM cannot win that race on this hardware, so the override ends up being what spins the fans, from near standstill straight to max. Above 85°C the governor is the wrong tool.

This also takes some of the sting out of #41 — fans engage proportionally on the way up instead of the 95°C override being the first thing that moves them.

## Verification

- `swift build -c release` clean (Swift 6.3.3, arm64, macOS 26).
- `swift test`: 48 tests in 8 suites, all pass.
- Running the rebuilt bundle on the affected M5 Pro.

## Caveats

The `MenuBarView` change is inference from log/`pmset` correlation, not a captured SwiftUI trace — I could not make the internal re-render write reproduce on demand. The other two changes are deterministic and stand on their own.

Two unrelated defects I noticed and deliberately left alone:

- `SMCConnection.readKey` never checks `output.result`, while `writeKey` explicitly does with a comment noting IOKit reports success on firmware-rejected calls. A rejected read currently returns `success: true`. Did not cause this bug, and tightening it could reject valid reads on hardware I cannot test.
- `ThermalMonitor.captureTopProcesses` returned `idle` for all 10,679 samples in my logs — `p_pctcpu` reads 0 on macOS 26, so the pre-spike process history is currently empty of signal.
