### PR TITLE
feat: remember the selected profile across launches

### DIFF
--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -13,6 +13,12 @@ import SwiftUI
 final class AppState: ObservableObject {
     @Published var latestStatus: ThermalStatus?
     @Published var activeProfile: FanProfile = .silent
+
+    /// Key for the last profile the user chose. Fan behaviour is a standing
+    /// preference, not a per-launch decision: without this, every restart,
+    /// update, crash or logout silently drops the machine back to Apple's curve
+    /// while the menu still reads whatever the user last picked.
+    private static let activeProfileKey = "activeProfileID"
     @Published var monitorState: MonitorState = .idle
     @Published var maxTemp: Float?
     @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
@@ -85,6 +91,10 @@ final class AppState: ObservableObject {
         // Show a previously-found update immediately, before any network call.
         availableUpdate = Self.storedAvailableUpdate()
 
+        // Before startMonitoring() — it hands activeProfile to the ThermalMonitor
+        // it constructs, so a restore after that point would not reach the monitor.
+        activeProfile = Self.restoredProfile()
+
         adoptDaemonStateOnLaunch()
 
         // Clean expired logs
@@ -96,6 +106,23 @@ final class AppState: ObservableObject {
         // so the first heartbeat poll can never land before adopt has applied the
         // launch state. The original synchronous adopt gave this ordering for free;
         // the async version must restore it explicitly.
+    }
+
+    /// Resolve the persisted profile id against the profiles that exist now.
+    /// Smart lives outside `loadAll()`, and a custom profile may have been deleted
+    /// since it was chosen — both fall back to Apple's default rather than leaving
+    /// the menu showing a profile the monitor isn't actually running.
+    private static func restoredProfile() -> FanProfile {
+        guard let id = UserDefaults.standard.string(forKey: activeProfileKey) else { return .silent }
+        if id == FanProfile.smart.id { return .smart }
+        return FanProfile.loadAll().first { $0.id == id } ?? .silent
+    }
+
+    /// Record an explicit user choice. Called only from the three places the user
+    /// expresses intent — never from the monitor's onUpdate, whose in-flight value
+    /// can still carry the previous profile for one tick after a switch.
+    private func persistProfile(_ profile: FanProfile) {
+        UserDefaults.standard.set(profile.id, forKey: Self.activeProfileKey)
     }
 
     /// Sync to whatever the daemon is actually holding at launch instead of
@@ -371,6 +398,7 @@ final class AppState: ObservableObject {
     func setSmart() {
         let took = seizeControl()
         activeProfile = .smart
+        persistProfile(.smart)
         monitor?.switchProfile(.smart)
         // Taking over a CLI hold: clear it so the unsupervised hold isn't
         // orphaned; the Smart tick then establishes supervised control. Off-main
@@ -397,6 +425,7 @@ final class AppState: ObservableObject {
                     return
                 }
                 self.activeProfile = .silent
+                self.persistProfile(.silent)
                 self.monitor?.switchProfile(.silent)
                 TFLogger.shared.profile("Reset to Default (Silent (Apple Default))")
             }
@@ -406,6 +435,7 @@ final class AppState: ObservableObject {
     func selectProfile(_ profile: FanProfile) {
         let took = seizeControl()
         activeProfile = profile
+        persistProfile(profile)
         monitor?.switchProfile(profile)
         TFLogger.shared.profile("Selected: \(profile.name)")
 


### PR DESCRIPTION
## What this fixes

`AppState.activeProfile` is initialised to `.silent` and never restored. Every app restart, update, crash or logout silently hands the machine back to Apple's fan curve.

There is no signal that it happened. The daemon keeps running, the menu bar icon stays where it was, and the only symptom is that the machine runs hotter than it did yesterday until someone notices and re-picks a profile. On a machine that heats quickly this is the difference between the curve engaging on schedule and the 95°C safety override being the first thing that spins the fans.

The current `UserDefaults` surface persists `useFahrenheit` and the update-check bookkeeping, but not the one setting the whole app exists to express.

## Changes

`Sources/ThermalForgeApp/AppState.swift` only, no new dependencies, no protocol or daemon changes.

- New `activeProfileKey` default. `restoredProfile()` resolves the stored id against `FanProfile.loadAll()` at launch.
- The restore runs **before `startMonitoring()`**. That ordering matters: `startMonitoring()` passes `activeProfile` into the `ThermalMonitor` it constructs, so restoring after that point would update the menu but leave the monitor on Silent.
- Persisted from the three places the user expresses intent — `selectProfile`, `setSmart`, `resetAuto` — rather than from a `didSet` on `activeProfile`. The monitor's `onUpdate` writes that property every 500ms and its in-flight value can still carry the previous profile for one tick after a `switchProfile`, so a `didSet` would briefly persist the profile the user just moved away from.
- `smart` is not in `loadAll()` and is resolved explicitly. A custom profile deleted since it was chosen falls back to `.silent`, so the menu can never show a profile the monitor is not actually running.

## Interaction with existing behaviour

- An active CLI hold is unaffected. `adoptDaemonStateOnLaunch` still reflects it and `onFanCommand` still bails while `externalHold != nil`; the restored profile simply does not act until the hold clears.
- `resetAuto` (the Default button) persists `.silent`, so "give me back Apple's curve" is itself remembered rather than being undone by the next launch.
- First launch on an existing install reads no key and returns `.silent`, which is today's behaviour.

## Verification

- `swift build -c release` clean (Swift 6.3.3, Xcode 26.6, arm64).
- `swift test`: 48 tests in 8 suites, all pass.
- Running on an M5 Pro (Mac17,8), macOS 26.6.2: profile survives quit/relaunch and reboot, and the monitor resumes on the restored curve rather than on Silent.

Independent of #44 — separate branch off `main`, no overlapping hunks.
