### PR TITLE
fix: show custom profiles in the menu bar and CLI (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,38 @@ Thermal polling runs at 100ms (matching Apple's own thermalmonitord cadence) for
 - **At ceiling and above:** Fan speed at the profile's maximum (60%/85%/100%).
 - **Ramp down:** Each profile has its own ramp-down rate. Max uses a gentle governor to let temps stabilize before backing off.
 
+### Custom profiles
+
+Drop a JSON file in `~/Library/Application Support/ThermalForge/profiles/`. A file whose `id` matches a built-in replaces it; any other `id` is added as a new profile. Both the menu bar picker and `thermalforge watch --profile <id>` read the same directory. Relaunch the app to pick up changes.
+
+This one keeps the `balanced` id, so it replaces the built-in Balanced rather than adding a sixth entry to the picker. It widens the band to 62–85°C and drops the cap to 45%, trading higher steady temperatures for less fan noise under sustained load:
+
+```json
+{
+  "id": "balanced",
+  "name": "Balanced",
+  "curve": {
+    "stopTemp": 50, "startTemp": 62, "ceilingTemp": 85,
+    "maxRPMPercent": 0.45, "curveShape": "easeIn",
+    "rampUpPerSec": 0.05, "rampDownPerSec": 0.025,
+    "sustainedTriggerSec": 8,
+    "handsOff": false, "alwaysOn": false, "instantEngage": false
+  }
+}
+```
+
+Give it any other `id` instead and it appears as an additional profile alongside the built-ins.
+
+Every `curve` field is required. A file is skipped, and the reason written to the app's log in `~/Library/Logs/ThermalForge/`, when it can't be read or decoded, claims the reserved `silent` or `smart` id (the code branches on both by id), or describes a curve that can't be used. The built-in stays in place when that happens. A usable curve needs:
+
+- `stopTemp` between 20°C and 90°C, and `startTemp` at least 5°C above it — the project's hysteresis rule, since start/stop cycling is the main cause of fan bearing wear
+- `startTemp` below and `ceilingTemp` no higher than the 95°C safety threshold, so the profile is reachable before the override fires
+- `ceilingTemp` above `startTemp`, or equal to it when `instantEngage` is set
+- `maxRPMPercent` in 0–1, positive ramp rates, `sustainedTriggerSec` of 0–300
+- `alwaysOn` off, since it would hold the fans at a fixed speed and never hand them back
+
+The 95°C safety override and the daemon's crash watchdog apply to custom profiles exactly as they do to the built-ins — they're enforced in the daemon, which knows nothing about profiles.
+
 ## Install
 
 ### Option A: Homebrew (recommended)

--- a/Sources/ThermalForgeApp/AppState.swift
+++ b/Sources/ThermalForgeApp/AppState.swift
@@ -13,6 +13,12 @@ import SwiftUI
 final class AppState: ObservableObject {
     @Published var latestStatus: ThermalStatus?
     @Published var activeProfile: FanProfile = .silent
+    /// Profiles offered in the menu bar picker: the built-ins plus any custom profiles in
+    /// `~/Library/Application Support/ThermalForge/profiles` (a custom file replaces the
+    /// built-in of the same id). Read once at launch and never reloaded — the picker is
+    /// rebuilt on every status update, so it must not touch the filesystem. Adding or
+    /// editing a profile file needs a relaunch to show up.
+    let availableProfiles: [FanProfile] = FanProfile.loadAll()
     @Published var monitorState: MonitorState = .idle
     @Published var maxTemp: Float?
     @Published var useFahrenheit: Bool = UserDefaults.standard.bool(forKey: "useFahrenheit") {
@@ -454,9 +460,12 @@ final class AppState: ObservableObject {
     }
 
     /// The profile to restore at launch: the persisted choice resolved against the known
-    /// profiles, or Silent when nothing is saved or the id no longer exists.
+    /// profiles, or Silent when nothing is saved or the id no longer exists. Resolves
+    /// against `availableProfiles` so a custom profile comes back too; Smart is appended
+    /// because it's surfaced by its own button rather than the picker.
     private func restoredProfile() -> FanProfile {
-        FanProfile.selectable(id: UserDefaults.standard.string(forKey: Self.selectedProfileKey))
+        FanProfile.selectable(id: UserDefaults.standard.string(forKey: Self.selectedProfileKey),
+                              from: availableProfiles + [.smart])
     }
 
     // MARK: - Daemon recovery

--- a/Sources/ThermalForgeApp/MenuBarView.swift
+++ b/Sources/ThermalForgeApp/MenuBarView.swift
@@ -94,12 +94,12 @@ struct MenuBarView: View {
             Picker("Profile", selection: Binding(
                 get: { appState.activeProfile.id },
                 set: { id in
-                    if let profile = FanProfile.builtIn.first(where: { $0.id == id }) {
+                    if let profile = appState.availableProfiles.first(where: { $0.id == id }) {
                         appState.selectProfile(profile)
                     }
                 }
             )) {
-                ForEach(FanProfile.builtIn) { profile in
+                ForEach(appState.availableProfiles) { profile in
                     HStack {
                         Text(profile.name)
                         Spacer()

--- a/Sources/ThermalForgeCore/Profile.swift
+++ b/Sources/ThermalForgeCore/Profile.swift
@@ -96,9 +96,63 @@ public struct FanProfile: Codable, Identifiable, Equatable {
             self.instantEngage = instantEngage
         }
 
+        /// Why this curve can't be used, or nil when it's sane. Applied to profiles loaded
+        /// from disk so a hand-edited file can't drive the fans nonsensically.
+        public var validationError: String? {
+            if handsOff { return nil } // Silent controls nothing; its thresholds are inert
+
+            // alwaysOn ignores temperature entirely and never hands the fans back to auto.
+            // A built-in may choose that; a file on disk may not.
+            if alwaysOn {
+                return "alwaysOn holds the fans at a fixed speed regardless of temperature"
+            }
+
+            if stopTemp < 20 || stopTemp > 90 {
+                return "stopTemp \(stopTemp)°C is out of range (20–90°C)"
+            }
+            // The project's stated rule: at least 5°C between stop and start, because
+            // start/stop cycling is the #1 fan bearing wear factor.
+            if startTemp - stopTemp < FanProfile.hysteresisDegrees {
+                return "startTemp \(startTemp)°C needs at least "
+                    + "\(Int(FanProfile.hysteresisDegrees))°C above stopTemp \(stopTemp)°C"
+            }
+            if startTemp >= FanProfile.safetyTempThreshold {
+                return "startTemp \(startTemp)°C is at or above the "
+                    + "\(Int(FanProfile.safetyTempThreshold))°C safety threshold"
+            }
+            // Instant-engage profiles have no proportional zone, so ceiling == start is the
+            // shape they declare. For anything else it collapses the curve to a step.
+            if instantEngage ? ceilingTemp < startTemp : ceilingTemp <= startTemp {
+                return "ceilingTemp \(ceilingTemp)°C leaves no proportional zone above "
+                    + "startTemp \(startTemp)°C"
+            }
+            // A ceiling past the safety threshold is unreachable — the 95°C override fires
+            // first, so the profile would never reach its own cap.
+            if ceilingTemp > FanProfile.safetyTempThreshold {
+                return "ceilingTemp \(ceilingTemp)°C is above the "
+                    + "\(Int(FanProfile.safetyTempThreshold))°C safety threshold"
+            }
+            if maxRPMPercent <= 0 || maxRPMPercent > 1 {
+                return "maxRPMPercent \(maxRPMPercent) is out of range (0–1)"
+            }
+            if rampUpPerSec <= 0 || rampDownPerSec <= 0 {
+                return "ramp rates must be positive"
+            }
+            // Generous upper bound: a long trigger is a legitimate choice for sustained
+            // workloads where you want the fans to stay out of the way through a warm-up.
+            if sustainedTriggerSec < 0 || sustainedTriggerSec > 300 {
+                return "sustainedTriggerSec \(sustainedTriggerSec) is out of range (0–300s)"
+            }
+            return nil
+        }
+
         /// Calculate the target fan speed percentage (0.0–1.0) for a given temperature.
         /// Returns nil if fans should be off (Apple auto).
         /// Returns 0.001 as a signal to keep fans at minimum RPM (hysteresis band).
+        ///
+        /// The curve runs from 0, so on hardware whose minimum RPM is a large fraction of
+        /// its maximum the lower part of the band sits below what the fan can turn and the
+        /// caller clamps it to minimum. See `ThermalMonitor.commandedPercent`.
         public func targetPercent(at temp: Float, fansCurrentlyRunning: Bool) -> Float? {
             // Always-on profiles ignore temperature
             if alwaysOn { return maxRPMPercent }
@@ -230,47 +284,106 @@ extension FanProfile {
     /// `builtIn`). Returns Silent when the id is nil (nothing saved) or unrecognized (a
     /// profile removed or renamed in a later version), so a stale saved id never crashes.
     public static func selectable(id: String?) -> FanProfile {
+        selectable(id: id, from: builtIn + [smart])
+    }
+
+    /// Resolve a persisted profile id against a caller-supplied list, so a custom profile
+    /// the user selected is restored rather than silently falling back to Silent.
+    public static func selectable(id: String?, from candidates: [FanProfile]) -> FanProfile {
         guard let id else { return .silent }
-        return (builtIn + [smart]).first { $0.id == id } ?? .silent
+        return candidates.first { $0.id == id } ?? .silent
     }
 }
 
 // MARK: - Persistence
 
 extension FanProfile {
-    private static var profilesDirectory: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/ThermalForge/profiles")
+    /// Ids that a file on disk may not claim, because the code branches on them by id.
+    ///
+    /// Smart is dispatched to its own adaptive path in ThermalMonitor, which reads only the
+    /// ramp rates and sustained trigger — a custom `smart.json` would have most of its curve
+    /// silently ignored, and would double up with Smart's own menu bar button. Silent is the
+    /// app's initial and reset-to state, held as a static, so overriding it would leave the
+    /// picker showing one profile while the monitor runs another.
+    static let reservedProfileIDs: Set<String> = ["smart", "silent"]
+
+    /// Where custom profiles live. Under `sudo` the effective user is root, whose home is
+    /// `/var/root` — the CLI has to resolve the invoking user's home or it would look in
+    /// the wrong place and find nothing, so SUDO_UID wins when it's set (same approach as
+    /// `thermalforge install`).
+    public static var defaultProfilesDirectory: URL {
+        var home = FileManager.default.homeDirectoryForCurrentUser
+        if geteuid() == 0,
+           let sudoUID = ProcessInfo.processInfo.environment["SUDO_UID"],
+           let uid = uid_t(sudoUID), uid != 0,
+           let pw = getpwuid(uid),
+           pw.pointee.pw_uid == uid, // the account must be the one SUDO_UID names
+           let dir = pw.pointee.pw_dir
+        {
+            home = URL(fileURLWithPath: String(cString: dir))
+        }
+        return home.appendingPathComponent("Library/Application Support/ThermalForge/profiles")
     }
 
-    public func save() throws {
-        let dir = Self.profilesDirectory
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    public func save(to directory: URL = FanProfile.defaultProfilesDirectory) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let data = try JSONEncoder().encode(self)
-        try data.write(to: dir.appendingPathComponent("\(id).json"))
+        try data.write(to: directory.appendingPathComponent("\(id).json"))
     }
 
-    public static func loadAll() -> [FanProfile] {
-        let dir = profilesDirectory
+    /// Built-in profiles merged with any custom ones on disk. A file whose id matches a
+    /// built-in replaces it; anything else is appended. Files that can't be read, can't be
+    /// decoded, claim a reserved id, or describe an unusable curve are skipped and logged —
+    /// a bad file must not take the fans with it.
+    public static func loadAll(from directory: URL = FanProfile.defaultProfilesDirectory) -> [FanProfile] {
         guard let files = try? FileManager.default.contentsOfDirectory(
-            at: dir, includingPropertiesForKeys: nil
+            at: directory, includingPropertiesForKeys: nil
         ) else {
             return builtIn
         }
 
         var profiles = builtIn
-        for file in files where file.pathExtension == "json" {
-            if let data = try? Data(contentsOf: file),
-               let profile = try? JSONDecoder().decode(FanProfile.self, from: data)
-            {
-                if let idx = profiles.firstIndex(where: { $0.id == profile.id }) {
-                    profiles[idx] = profile
-                } else {
-                    profiles.append(profile)
-                }
+        for file in files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        where file.pathExtension == "json" {
+            let profile: FanProfile
+            do {
+                profile = try JSONDecoder().decode(FanProfile.self, from: Data(contentsOf: file))
+            } catch {
+                TFLogger.shared.error("Profile file \(file.lastPathComponent) unreadable: \(error)")
+                continue
+            }
+
+            if reservedProfileIDs.contains(profile.id) {
+                TFLogger.shared.error("Profile '\(profile.id)' rejected: that id is reserved")
+                continue
+            }
+            // A hand-edited file that would drive the fans nonsensically is skipped
+            // rather than offered, the same way calibration data is screened on load.
+            if let error = profile.curve.validationError {
+                TFLogger.shared.error("Profile '\(profile.id)' rejected: \(error)")
+                continue
+            }
+
+            if let idx = profiles.firstIndex(where: { $0.id == profile.id }) {
+                profiles[idx] = profile
+            } else {
+                profiles.append(profile)
             }
         }
-        return profiles
+        return orderedByCeiling(profiles)
+    }
+
+    /// Order profiles by how loud each is willing to get, so the picker escalates from
+    /// quietest to loudest and a custom profile lands where a reader expects rather than
+    /// tacked on after Max. The built-ins are already in this order (0, 0.60, 0.85, 1.0),
+    /// so a machine with no custom profiles sees exactly the list it saw before.
+    /// Ties keep insertion order, which puts a built-in ahead of a custom profile.
+    static func orderedByCeiling(_ profiles: [FanProfile]) -> [FanProfile] {
+        profiles.enumerated().sorted { lhs, rhs in
+            let a = lhs.element.curve.maxRPMPercent
+            let b = rhs.element.curve.maxRPMPercent
+            return a == b ? lhs.offset < rhs.offset : a < b
+        }.map(\.element)
     }
 }
 

--- a/Sources/thermalforge/ThermalForge.swift
+++ b/Sources/thermalforge/ThermalForge.swift
@@ -343,7 +343,8 @@ struct Watch: ParsableCommand {
         abstract: "Monitor temps and auto-adjust fans based on a profile"
     )
 
-    @Option(name: .shortAndLong, help: "Profile: silent, balanced, performance, max")
+    @Option(name: .shortAndLong,
+            help: "Profile: silent, balanced, performance, max, smart, or a custom profile id")
     var profile: String = "balanced"
 
     @Option(name: .shortAndLong, help: "Poll interval in seconds (default 0.1 = 100ms)")
@@ -354,7 +355,9 @@ struct Watch: ParsableCommand {
 
     func run() throws {
         warnIfDaemonVersionMismatch()
-        let profiles = FanProfile.builtIn
+        // Built-ins plus Smart plus anything in Application Support — the same set the
+        // menu bar offers, so `watch` and the app agree on what a profile id means.
+        let profiles = FanProfile.loadAll() + [.smart]
         guard let selectedProfile = profiles.first(where: { $0.id == profile }) else {
             throw ValidationError(
                 "Unknown profile '\(profile)'. Options: \(profiles.map(\.id).joined(separator: ", "))"

--- a/Tests/ThermalForgeTests/ProfileTests.swift
+++ b/Tests/ThermalForgeTests/ProfileTests.swift
@@ -96,8 +96,18 @@ struct ProfileTests {
         #expect(smartDecoded == FanProfile.smart)
     }
 
+    /// A throwaway profiles directory. Tests never touch the real one — a user with a
+    /// hand-written balanced.json would otherwise have it overwritten by `swift test`.
+    private static func scratchDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("ThermalForgeTests-\(UUID().uuidString)")
+    }
+
     @Test("Custom profile saves and loads")
     func saveLoad() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
         let custom = FanProfile(
             id: "test_custom",
             name: "Test Custom",
@@ -106,9 +116,9 @@ struct ProfileTests {
                                     rampUpPerSec: 0.08, sustainedTriggerSec: 3)
         )
 
-        try custom.save()
+        try custom.save(to: dir)
 
-        let loaded = FanProfile.loadAll()
+        let loaded = FanProfile.loadAll(from: dir)
         let found = loaded.first { $0.id == "test_custom" }
         #expect(found != nil)
         #expect(found?.curve.startTemp == 55)
@@ -116,11 +126,43 @@ struct ProfileTests {
         #expect(found?.curve.curveShape == .easeOut)
         #expect(found?.curve.rampUpPerSec == 0.08)
         #expect(found?.curve.sustainedTriggerSec == 3)
+    }
 
-        // Clean up
-        let path = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/ThermalForge/profiles/test_custom.json")
-        try? FileManager.default.removeItem(at: path)
+    @Test("A missing profiles directory yields the built-ins")
+    func loadAllWithNoDirectory() {
+        #expect(FanProfile.loadAll(from: Self.scratchDirectory()) == FanProfile.builtIn)
+    }
+
+    @Test("A custom profile sorts by loudness, not onto the end of the list")
+    func customProfilesSortByCeiling() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // A 45% cap is quieter than Balanced's 60%, so it belongs between Silent and
+        // Balanced. Appending would put it after Max, reading as the most aggressive entry.
+        try FanProfile(
+            id: "test_low_cap", name: "Test Low Cap",
+            curve: FanProfile.Curve(startTemp: 62, ceilingTemp: 85, maxRPMPercent: 0.45,
+                                    curveShape: .easeIn)
+        ).save(to: dir)
+
+        #expect(FanProfile.loadAll(from: dir).map(\.id)
+            == ["silent", "test_low_cap", "balanced", "performance", "max"])
+    }
+
+    @Test("Ordering leaves the built-in list exactly as shipped")
+    func builtInOrderUnchanged() {
+        #expect(FanProfile.orderedByCeiling(FanProfile.builtIn) == FanProfile.builtIn)
+    }
+
+    @Test("Profiles sharing a cap keep insertion order, so a built-in stays ahead")
+    func equalCeilingsKeepInsertionOrder() {
+        let sameAsBalanced = FanProfile(
+            id: "test_tie", name: "Test Tie",
+            curve: FanProfile.Curve(startTemp: 58, ceilingTemp: 72, maxRPMPercent: 0.60)
+        )
+        let ordered = FanProfile.orderedByCeiling(FanProfile.builtIn + [sameAsBalanced])
+        #expect(ordered.map(\.id) == ["silent", "balanced", "test_tie", "performance", "max"])
     }
 
     @Test("Safety threshold is 95°C")
@@ -303,5 +345,150 @@ struct ProfileTests {
         #expect(FanProfile.performance.curve.sustainedTriggerSec == 4)  // Responsive
         #expect(FanProfile.max.curve.sustainedTriggerSec == 5)          // Attack dog threshold
         #expect(FanProfile.smart.curve.sustainedTriggerSec == 6)        // Proactive
+    }
+
+    // MARK: - Curve Validation
+
+    @Test("Every profile offered in the picker passes the validation applied to loaded ones")
+    func builtInProfilesValidate() {
+        // Smart is excluded deliberately: its 3°C band is under the project's 5°C rule, and
+        // it never goes through this path because `smart` is a reserved id on disk.
+        for profile in FanProfile.builtIn {
+            #expect(profile.curve.validationError == nil,
+                    "\(profile.id): \(profile.curve.validationError ?? "")")
+        }
+    }
+
+    @Test("Nonsensical curves are rejected")
+    func invalidCurvesAreRejected() {
+        // Start at or below stop: the hysteresis band is empty or inverted.
+        #expect(FanProfile.Curve(stopTemp: 60, startTemp: 55).validationError != nil)
+        #expect(FanProfile.Curve(stopTemp: 55, startTemp: 55).validationError != nil)
+        // Ceiling below start: the proportional zone runs backwards.
+        #expect(FanProfile.Curve(startTemp: 70, ceilingTemp: 60).validationError != nil)
+        // Ceiling equal to start without instantEngage: the curve collapses to a step.
+        #expect(FanProfile.Curve(startTemp: 65, ceilingTemp: 65).validationError != nil)
+        // Speeds and rates outside their ranges.
+        #expect(FanProfile.Curve(maxRPMPercent: 0).validationError != nil)
+        #expect(FanProfile.Curve(maxRPMPercent: 1.5).validationError != nil)
+        #expect(FanProfile.Curve(rampUpPerSec: 0).validationError != nil)
+        #expect(FanProfile.Curve(sustainedTriggerSec: 400).validationError != nil)
+        #expect(FanProfile.Curve(sustainedTriggerSec: -1).validationError != nil)
+        // Engaging above the safety threshold would never fire before the override does.
+        #expect(FanProfile.Curve(startTemp: 97, ceilingTemp: 99).validationError != nil)
+        // A ceiling past the override is unreachable.
+        #expect(FanProfile.Curve(startTemp: 60, ceilingTemp: 120).validationError != nil)
+        // alwaysOn never hands the fans back to auto.
+        #expect(FanProfile.Curve(alwaysOn: true).validationError != nil)
+
+        // Max's ceiling == start is allowed: instant engage has no proportional zone.
+        #expect(FanProfile.Curve(stopTemp: 50, startTemp: 65, ceilingTemp: 65,
+                                 maxRPMPercent: 1.0, instantEngage: true).validationError == nil)
+        // handsOff short-circuits: Silent controls nothing, so its thresholds are inert.
+        #expect(FanProfile.Curve(stopTemp: 99, startTemp: 1, handsOff: true)
+            .validationError == nil)
+    }
+
+    @Test("Validation boundaries are inclusive where the message says they are")
+    func validationBoundaries() {
+        // Exactly the project's 5°C hysteresis band: allowed.
+        #expect(FanProfile.Curve(stopTemp: 50, startTemp: 55).validationError == nil)
+        // A whisker under it: rejected.
+        #expect(FanProfile.Curve(stopTemp: 50, startTemp: 54.9).validationError != nil)
+        // Exactly the safety threshold: startTemp rejected, ceilingTemp allowed.
+        #expect(FanProfile.Curve(startTemp: 95, ceilingTemp: 99).validationError != nil)
+        #expect(FanProfile.Curve(startTemp: 88, ceilingTemp: 95).validationError == nil)
+        // Full speed and the trigger ceiling are both legal.
+        #expect(FanProfile.Curve(maxRPMPercent: 1.0).validationError == nil)
+        #expect(FanProfile.Curve(sustainedTriggerSec: 300).validationError == nil)
+        #expect(FanProfile.Curve(sustainedTriggerSec: 301).validationError != nil)
+    }
+
+    @Test("A malformed profile file is skipped, leaving the built-in in place")
+    func malformedProfileIsSkipped() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // ceilingTemp below startTemp — the fan would never reach its cap.
+        try FanProfile(
+            id: "performance",
+            name: "Performance",
+            curve: FanProfile.Curve(stopTemp: 50, startTemp: 80, ceilingTemp: 60)
+        ).save(to: dir)
+
+        let performance = FanProfile.loadAll(from: dir).first { $0.id == "performance" }
+        #expect(performance?.curve.startTemp == 55)   // shipped value, not the broken 80
+        #expect(performance?.curve.ceilingTemp == 65)
+    }
+
+    @Test("Undecodable JSON is skipped without taking the rest of the directory with it")
+    func undecodableFileIsSkipped() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let good = FanProfile(id: "test_good", name: "Good",
+                              curve: FanProfile.Curve(startTemp: 62, ceilingTemp: 85,
+                                                      maxRPMPercent: 0.45))
+        try good.save(to: dir)
+        // Partial JSON: Curve's properties are non-optional, so this cannot decode.
+        try Data(#"{"id":"test_partial","name":"Partial","curve":{"startTemp":62}}"#.utf8)
+            .write(to: dir.appendingPathComponent("test_partial.json"))
+
+        let loaded = FanProfile.loadAll(from: dir)
+        #expect(loaded.contains { $0.id == "test_good" })
+        #expect(!loaded.contains { $0.id == "test_partial" })
+    }
+
+    @Test("A file claiming the reserved smart id is rejected, not offered alongside Smart")
+    func reservedIDIsRejected() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // ThermalMonitor dispatches "smart" to its own adaptive path, which reads almost
+        // none of this curve — offering it would be a profile that silently doesn't apply.
+        try FanProfile(id: "smart", name: "My Smart",
+                       curve: FanProfile.Curve(startTemp: 70, ceilingTemp: 90,
+                                               maxRPMPercent: 0.5)).save(to: dir)
+
+        let loaded = FanProfile.loadAll(from: dir)
+        #expect(!loaded.contains { $0.id == "smart" })
+    }
+
+    // MARK: - Custom Profile Discovery
+
+    @Test("selectable(id:from:) restores a custom profile the user had selected")
+    func selectableFromCustomList() {
+        let custom = FanProfile(
+            id: "test_custom_profile",
+            name: "Test Custom Profile",
+            curve: FanProfile.Curve(startTemp: 62, ceilingTemp: 85, maxRPMPercent: 0.45)
+        )
+        let available = FanProfile.builtIn + [.smart, custom]
+
+        #expect(FanProfile.selectable(id: "test_custom_profile", from: available).id == "test_custom_profile")
+        #expect(FanProfile.selectable(id: "smart", from: available).id == "smart")
+        // An id that vanished (profile deleted between launches) falls back to Silent.
+        #expect(FanProfile.selectable(id: "test_custom_profile", from: FanProfile.builtIn).id == "silent")
+        #expect(FanProfile.selectable(id: nil, from: available).id == "silent")
+    }
+
+    @Test("A custom profile overrides a built-in with the same id")
+    func customOverridesBuiltIn() throws {
+        let dir = Self.scratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try FanProfile(
+            id: "balanced",
+            name: "Balanced",
+            curve: FanProfile.Curve(startTemp: 62, ceilingTemp: 85, maxRPMPercent: 0.45,
+                                    curveShape: .easeIn)
+        ).save(to: dir)
+
+        let loaded = FanProfile.loadAll(from: dir)
+        // Still exactly one "balanced" — the custom file replaces it, not appends.
+        #expect(loaded.filter { $0.id == "balanced" }.count == 1)
+        let balanced = loaded.first { $0.id == "balanced" }
+        #expect(balanced?.curve.startTemp == 62)
+        #expect(balanced?.curve.maxRPMPercent == 0.45)
     }
 }


### PR DESCRIPTION
## What

`FanProfile.loadAll()` reads custom profiles from `~/Library/Application Support/ThermalForge/profiles`, but nothing calls it. `MenuBarView` and `watch` both use `FanProfile.builtIn`, so a saved custom profile never appears. Second half of #28; the install self-deletion half is already fixed on main.

## Behaviour change

None on a machine with no custom profile files, except one thing.

`Curve.targetPercent` is byte-identical to main. Tick loop, ramp governors and daemon untouched. Ordering sorts by `maxRPMPercent` ascending, reproducing the built-in order (0, 0.60, 0.85, 1.0); a test asserts `orderedByCeiling(builtIn) == builtIn`.

The exception: `watch --profile smart` used to throw a `ValidationError` because Smart isn't in `builtIn`. It now works.

## Changes

- `AppState` publishes `availableProfiles`, read once at launch. The picker rebuilds on every status update, so it can't touch the filesystem.
- Launch restore resolves the saved id against that list, so a custom profile comes back instead of falling back to Silent.
- `loadAll(from:)` and `save(to:)` take a directory. The existing tests wrote into the real Application Support directory and deleted afterwards, destroying a user's own `balanced.json`.
- The profiles directory resolves through `SUDO_UID` when running as root, as `install` already does, cross-checked against the uid. Without it the root CLI reads `/var/root` and finds nothing.
- Profiles from disk are screened by `Curve.validationError`, the same way `CalibrationData` is screened on load. Hand-editing JSON is the only way to make one today and nothing validated it. Unreadable files are logged instead of disappearing.
- `silent` and `smart` are reserved ids because the code branches on both. A custom `smart.json` would have most of its curve ignored by Smart's adaptive path; a custom `silent.json` would show one profile in the picker while the monitor ran another.
- Ordering, so a profile quieter than Balanced doesn't sort after Max. Most separable commit if you'd rather decide ordering yourself.

## Safety

The daemon speaks only RPM and knows nothing about profiles, so the 95°C override and heartbeat watchdog cover custom profiles the same as built-ins. Validation rejects curves that engage above the safety threshold or set `alwaysOn`, and enforces the 5°C hysteresis rule so a hand-written file can't cycle the fans on sensor noise.

## Overlap with open PRs

#44 replaces this `Picker` with `Button` rows. The two changes are orthogonal: #44 changes the control, this changes what the rows are built from. Whichever lands first, the other is a small rebase, and I'm happy to do that rebase rather than make you resolve it.

## Two notes

#46 proposes a settings UI covering custom curves, per-profile enable/disable and moving Smart inline, and someone has offered to prototype it. This PR doesn't prejudge that; it surfaces the JSON `loadAll()` already reads. If #46 lands, the ordering here is the first thing to redo.

The README sells against tools that require manual configuration, and this adds a section on hand-writing JSON. `loadAll()`, `save()` and the profiles directory are already yours; this only makes them reachable. Drop the README commit if you disagree, the code stands without it.

## Testing

61 tests, `swift build` and `swift test` clean. Every filesystem test uses a UUID scratch directory under `temporaryDirectory`, so the suite no longer touches the real profiles directory.
